### PR TITLE
Add Python API helper scripts

### DIFF
--- a/pytools/README.md
+++ b/pytools/README.md
@@ -1,0 +1,19 @@
+# NocoBase Python Tools
+
+This directory provides a simple Python library for interacting with the NocoBase REST API.
+It can create collections from SQL files and import CSV data into an existing collection.
+
+## Usage
+
+Run the module as a script:
+
+```bash
+python -m nocobase_api --base-url http://localhost:13000/api \
+    --username admin --password secret \
+    --sql schema.sql \
+    --csv data.csv --collection posts
+```
+
+Only the options you need are required. Use `--sql` to create tables from a SQL
+file and `--csv` with `--collection` to import CSV rows.
+

--- a/pytools/nocobase_api/__init__.py
+++ b/pytools/nocobase_api/__init__.py
@@ -1,0 +1,3 @@
+from .client import NocoBaseClient
+from .sql_utils import parse_sql_file
+

--- a/pytools/nocobase_api/__main__.py
+++ b/pytools/nocobase_api/__main__.py
@@ -1,0 +1,28 @@
+import argparse
+from .client import NocoBaseClient
+from .bulk_tools import create_tables_from_sql, import_csv
+
+
+def main():
+    parser = argparse.ArgumentParser(description="NocoBase API helper")
+    parser.add_argument("--base-url", required=True, help="Base API URL, e.g. http://localhost:13000/api")
+    parser.add_argument("--username", required=True, help="Login username")
+    parser.add_argument("--password", required=True, help="Login password")
+    parser.add_argument("--sql", help="SQL file for creating tables")
+    parser.add_argument("--csv", help="CSV file for importing records")
+    parser.add_argument("--collection", help="Target collection for CSV import")
+    args = parser.parse_args()
+
+    client = NocoBaseClient(args.base_url, args.username, args.password)
+    client.sign_in()
+
+    if args.sql:
+        create_tables_from_sql(client, args.sql)
+
+    if args.csv and args.collection:
+        import_csv(client, args.collection, args.csv)
+
+
+if __name__ == "__main__":
+    main()
+

--- a/pytools/nocobase_api/bulk_tools.py
+++ b/pytools/nocobase_api/bulk_tools.py
@@ -1,0 +1,17 @@
+import csv
+from .client import NocoBaseClient
+from .sql_utils import parse_sql_file
+
+
+def create_tables_from_sql(client: NocoBaseClient, sql_path: str):
+    tables = parse_sql_file(sql_path)
+    for table in tables:
+        client.create_collection(table["name"], table["fields"])
+
+
+def import_csv(client: NocoBaseClient, collection: str, csv_path: str):
+    with open(csv_path, newline="", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            client.create_record(collection, row)
+

--- a/pytools/nocobase_api/client.py
+++ b/pytools/nocobase_api/client.py
@@ -1,0 +1,46 @@
+import json
+import urllib.request
+import urllib.parse
+
+
+class NocoBaseClient:
+    """Simple client for interacting with the NocoBase REST API."""
+
+    def __init__(self, base_url: str, username: str, password: str, authenticator: str = "password"):
+        self.base_url = base_url.rstrip('/')
+        self.username = username
+        self.password = password
+        self.authenticator = authenticator
+        self.token = None
+
+    def _request(self, method: str, path: str, data: dict | None = None) -> dict:
+        url = f"{self.base_url}/{path.lstrip('/')}"
+        headers = {"Content-Type": "application/json"}
+        if self.token:
+            headers["Authorization"] = f"Bearer {self.token}"
+        body = None
+        if data is not None:
+            body = json.dumps(data).encode()
+        req = urllib.request.Request(url, data=body, headers=headers, method=method)
+        with urllib.request.urlopen(req) as resp:
+            resp_data = resp.read()
+            if not resp_data:
+                return {}
+            return json.loads(resp_data.decode())
+
+    def sign_in(self) -> None:
+        payload = {"email": self.username, "password": self.password}
+        response = self._request("POST", "auth:signIn", data=payload)
+        token = response.get("data", {}).get("token")
+        if not token:
+            raise RuntimeError("Failed to obtain token")
+        self.token = token
+
+    def create_collection(self, name: str, fields: list[dict]) -> dict:
+        values = {"name": name, "template": "general", "fields": fields}
+        return self._request("POST", "collections:create", data={"values": values})
+
+    def create_record(self, collection: str, values: dict) -> dict:
+        path = f"{collection}:create"
+        return self._request("POST", path, data={"values": values})
+

--- a/pytools/nocobase_api/sql_utils.py
+++ b/pytools/nocobase_api/sql_utils.py
@@ -1,0 +1,42 @@
+import re
+from typing import List, Dict
+
+
+def map_sql_type(sql_type: str) -> str:
+    sql_type = sql_type.lower()
+    if sql_type.startswith("int") or sql_type.startswith("bigint"):
+        return "integer"
+    if sql_type.startswith("float") or sql_type.startswith("double") or sql_type.startswith("decimal"):
+        return "float"
+    if sql_type.startswith("bool") or sql_type == "tinyint(1)":
+        return "boolean"
+    if sql_type.startswith("date") and not sql_type.startswith("datetime"):
+        return "date"
+    if sql_type.startswith("timestamp") or sql_type.startswith("datetime"):
+        return "datetime"
+    if sql_type.startswith("text"):
+        return "text"
+    return "string"
+
+
+def parse_sql_file(path: str) -> List[Dict[str, any]]:
+    with open(path, "r", encoding="utf-8") as f:
+        content = f.read()
+
+    tables = []
+    pattern = re.compile(r"CREATE\s+TABLE\s+`?(\w+)`?\s*\((.*?)\);", re.S | re.I)
+    for table_name, body in pattern.findall(content):
+        fields = []
+        columns = [c.strip() for c in re.split(r",\s*(?![^()]*\))", body) if c.strip()]
+        for col in columns:
+            if col.upper().startswith("PRIMARY KEY") or col.upper().startswith("CONSTRAINT") or col.upper().startswith("FOREIGN KEY"):
+                continue
+            m = re.match(r"`?(\w+)`?\s+([\w()]+)", col)
+            if not m:
+                continue
+            name, dtype = m.groups()
+            field_type = map_sql_type(dtype)
+            interface = "textarea" if field_type == "text" else "input"
+            fields.append({"name": name, "type": field_type, "interface": interface})
+        tables.append({"name": table_name, "fields": fields})
+    return tables


### PR DESCRIPTION
## Summary
- add `pytools` directory with Python helper scripts for NocoBase
- provide `NocoBaseClient` for calling REST API
- parse SQL files and import CSV data with simple utilities

## Testing
- `python3 -m py_compile pytools/nocobase_api/*.py`

------
https://chatgpt.com/codex/tasks/task_e_685bd43a9070832da99e8b9158080225