### PR TITLE
Fix authentication header in pytools

### DIFF
--- a/pytools/README.md
+++ b/pytools/README.md
@@ -5,20 +5,25 @@
 
 ## 使用方法
 
-在命令行中直接运行模块：
+在命令行中直接运行模块（`--base-url` 末尾应包含 `/api`，如未提供会自
+动补全）：
 
 ```bash
 python -m nocobase_api --base-url http://localhost:13000/api \
     --username admin --password secret \
+    --authenticator goout \
     --sql schema.sql \
     --csv data.csv --collection posts
 ```
 
 参数说明：
 
-- `--base-url`：API 地址，例如 `http://localhost:13000/api`。
+- `--base-url`：API 地址，例如 `http://localhost:13000/api`。若未以
+  `/api` 结尾，脚本会自动补全。
 - `--username`：登录用户名。
 - `--password`：登录密码。
+- `--authenticator`：登录方式标识，默认为 `basic`，根据后台配置选择
+  `goout` 等值。
 - `--sql`：包含 `CREATE TABLE` 语句的 SQL 文件，可根据其中定义创建集合。
 - `--csv`：要导入的 CSV 文件。
 - `--collection`：CSV 数据要导入的集合名称。

--- a/pytools/nocobase_api/__main__.py
+++ b/pytools/nocobase_api/__main__.py
@@ -15,6 +15,11 @@ def main():
     parser.add_argument("--base-url", required=True, help="API 地址，例如 http://localhost:13000/api")
     parser.add_argument("--username", required=True, help="登录用户名")
     parser.add_argument("--password", required=True, help="登录密码")
+    parser.add_argument(
+        "--authenticator",
+        default="basic",
+        help="登录方式标识，例如 basic/goout",
+    )
     # 选项：指定 SQL 文件创建数据表
     parser.add_argument("--sql", help="包含建表语句的 SQL 文件")
     # 选项：导入 CSV 数据及对应集合名称
@@ -22,7 +27,9 @@ def main():
     parser.add_argument("--collection", help="CSV 数据对应的集合名称")
     args = parser.parse_args()
 
-    client = NocoBaseClient(args.base_url, args.username, args.password)
+    client = NocoBaseClient(
+        args.base_url, args.username, args.password, authenticator=args.authenticator
+    )
     # 登录以获取 token
     client.sign_in()
 

--- a/pytools/nocobase_api/client.py
+++ b/pytools/nocobase_api/client.py
@@ -8,9 +8,12 @@ import urllib.parse
 class NocoBaseClient:
     """与 NocoBase REST API 交互的简单客户端"""
 
-    def __init__(self, base_url: str, username: str, password: str, authenticator: str = "password"):
+    def __init__(self, base_url: str, username: str, password: str, authenticator: str = "basic"):
         """初始化客户端并保存认证信息"""
         self.base_url = base_url.rstrip('/')
+        # 如果末尾未包含 /api，则自动补全，避免用户遗漏
+        if not self.base_url.endswith('/api'):
+            self.base_url += '/api'
         self.username = username
         self.password = password
         self.authenticator = authenticator
@@ -20,6 +23,9 @@ class NocoBaseClient:
         """内部请求方法，用于发送 HTTP 请求"""
         url = f"{self.base_url}/{path.lstrip('/')}"
         headers = {"Content-Type": "application/json"}
+        # 登录方式标识，默认为 "basic"，可在实例化时传入
+        if self.authenticator:
+            headers["X-Authenticator"] = self.authenticator
         if self.token:
             headers["Authorization"] = f"Bearer {self.token}"  # 认证信息
         body = None


### PR DESCRIPTION
## Summary
- add `--authenticator` option to CLI
- include `X-Authenticator` header in HTTP client
- document authenticator usage in readme
- default authenticator is `basic`
- auto-append `/api` to base URL if missing

## Testing
- `python -m pytools.nocobase_api --help`


------
https://chatgpt.com/codex/tasks/task_e_685cb644da80832d997d40d41de6d90a