### PR TITLE
Add debug logging to nocobase_api tools

### DIFF
--- a/pytools/nocobase_api/__main__.py
+++ b/pytools/nocobase_api/__main__.py
@@ -1,4 +1,5 @@
 import argparse
+import logging
 from .client import NocoBaseClient
 from .bulk_tools import create_tables_from_sql, import_csv
 
@@ -25,20 +26,35 @@ def main():
     # 选项：导入 CSV 数据及对应集合名称
     parser.add_argument("--csv", help="要导入的 CSV 文件")
     parser.add_argument("--collection", help="CSV 数据对应的集合名称")
+    parser.add_argument(
+        "--debug",
+        action="store_true",
+        help="输出调试信息",
+    )
     args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.debug else logging.INFO,
+        format="%(message)s",
+    )
+
+    logging.info("Connecting to NocoBase at %s", args.base_url)
 
     client = NocoBaseClient(
         args.base_url, args.username, args.password, authenticator=args.authenticator
     )
     # 登录以获取 token
     client.sign_in()
+    logging.info("Signed in successfully")
 
     if args.sql:
         # 根据 SQL 文件创建数据表
+        logging.info("Creating collections from %s", args.sql)
         create_tables_from_sql(client, args.sql)
 
     if args.csv and args.collection:
         # 将 CSV 文件中的记录导入指定集合
+        logging.info("Importing %s into %s", args.csv, args.collection)
         import_csv(client, args.collection, args.csv)
 
 

--- a/pytools/nocobase_api/bulk_tools.py
+++ b/pytools/nocobase_api/bulk_tools.py
@@ -1,4 +1,5 @@
 import csv
+import logging
 from .client import NocoBaseClient
 from .sql_utils import parse_sql_file
 
@@ -12,6 +13,7 @@ def create_tables_from_sql(client: NocoBaseClient, sql_path: str):
     tables = parse_sql_file(sql_path)
     for table in tables:
         # table 为解析后的结构，包括集合名称和字段列表
+        logging.info("Creating collection %s", table["name"])
         client.create_collection(table["name"], table["fields"])
 
 
@@ -21,5 +23,6 @@ def import_csv(client: NocoBaseClient, collection: str, csv_path: str):
         reader = csv.DictReader(f)
         for row in reader:
             # 每一行作为字典传递给 API 创建记录
+            logging.debug("Creating record: %s", row)
             client.create_record(collection, row)
 

--- a/pytools/nocobase_api/client.py
+++ b/pytools/nocobase_api/client.py
@@ -1,6 +1,8 @@
 import json
+import logging
 import urllib.request
 import urllib.parse
+import urllib.error
 
 """NocoBase REST API 简易客户端"""
 
@@ -32,11 +34,18 @@ class NocoBaseClient:
         if data is not None:
             body = json.dumps(data).encode()
         req = urllib.request.Request(url, data=body, headers=headers, method=method)
-        with urllib.request.urlopen(req) as resp:
-            resp_data = resp.read()
-            if not resp_data:
-                return {}
-            return json.loads(resp_data.decode())
+        logging.debug("%s %s", method, url)
+        if data is not None:
+            logging.debug("Payload: %s", data)
+        try:
+            with urllib.request.urlopen(req) as resp:
+                resp_data = resp.read()
+        except urllib.error.HTTPError as e:
+            logging.error("HTTP %s error for %s: %s", e.code, url, e.read().decode())
+            raise
+        if not resp_data:
+            return {}
+        return json.loads(resp_data.decode())
 
     def sign_in(self) -> None:
         """登录并保存返回的 token"""


### PR DESCRIPTION
## Summary
- add `--debug` flag and print progress info when running Python CLI
- log table creation and CSV import steps
- show request details and HTTP errors in client

## Testing
- `python -m pytools.nocobase_api --help`
- `yarn test` *(fails: This package doesn't seem to be present in your lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_685cc22eab6c832d8d712801ffd0b97b