### PR TITLE
Add detailed debugging to Python tools

### DIFF
--- a/pytools/README.md
+++ b/pytools/README.md
@@ -13,7 +13,8 @@ python -m nocobase_api --base-url http://localhost:13000/api \
     --username admin --password secret \
     --authenticator goout \
     --sql schema.sql \
-    --csv data.csv --collection posts
+    --csv data.csv --collection posts \
+    --debug
 ```
 
 参数说明：
@@ -27,6 +28,7 @@ python -m nocobase_api --base-url http://localhost:13000/api \
 - `--sql`：包含 `CREATE TABLE` 语句的 SQL 文件，可根据其中定义创建集合。
 - `--csv`：要导入的 CSV 文件。
 - `--collection`：CSV 数据要导入的集合名称。
+- `--debug`：输出调试信息，便于排查脚本执行过程中的问题。
 
 根据需要选择参数：只创建集合时只需提供 `--sql`；仅导入数据时需要同时指定 `--csv` 与 `--collection`。
 

--- a/pytools/nocobase_api/__main__.py
+++ b/pytools/nocobase_api/__main__.py
@@ -38,11 +38,14 @@ def main():
         format="%(message)s",
     )
 
+    logging.debug("Arguments: %s", vars(args))
+
     logging.info("Connecting to NocoBase at %s", args.base_url)
 
     client = NocoBaseClient(
         args.base_url, args.username, args.password, authenticator=args.authenticator
     )
+    logging.debug("Client initialized")
     # 登录以获取 token
     client.sign_in()
     logging.info("Signed in successfully")

--- a/pytools/nocobase_api/bulk_tools.py
+++ b/pytools/nocobase_api/bulk_tools.py
@@ -10,7 +10,9 @@ from .sql_utils import parse_sql_file
 
 def create_tables_from_sql(client: NocoBaseClient, sql_path: str):
     """根据 SQL 文件创建集合和字段"""
+    logging.debug("Parsing SQL file %s", sql_path)
     tables = parse_sql_file(sql_path)
+    logging.debug("Tables to create: %s", tables)
     for table in tables:
         # table 为解析后的结构，包括集合名称和字段列表
         logging.info("Creating collection %s", table["name"])
@@ -19,6 +21,7 @@ def create_tables_from_sql(client: NocoBaseClient, sql_path: str):
 
 def import_csv(client: NocoBaseClient, collection: str, csv_path: str):
     """将 CSV 数据导入指定集合"""
+    logging.debug("Importing CSV %s into %s", csv_path, collection)
     with open(csv_path, newline="", encoding="utf-8") as f:
         reader = csv.DictReader(f)
         for row in reader:

--- a/pytools/nocobase_api/client.py
+++ b/pytools/nocobase_api/client.py
@@ -37,15 +37,23 @@ class NocoBaseClient:
         logging.debug("%s %s", method, url)
         if data is not None:
             logging.debug("Payload: %s", data)
+        logging.debug("Request headers: %s", headers)
         try:
             with urllib.request.urlopen(req) as resp:
+                status = resp.status
                 resp_data = resp.read()
         except urllib.error.HTTPError as e:
-            logging.error("HTTP %s error for %s: %s", e.code, url, e.read().decode())
+            body = e.read().decode()
+            logging.error("HTTP %s error for %s: %s", e.code, url, body)
             raise
-        if not resp_data:
-            return {}
-        return json.loads(resp_data.decode())
+        except urllib.error.URLError as e:
+            logging.error("Failed to reach %s: %s", url, e.reason)
+            raise
+        logging.debug("Response status: %s", status)
+        if resp_data:
+            logging.debug("Response body: %s", resp_data.decode())
+            return json.loads(resp_data.decode())
+        return {}
 
     def sign_in(self) -> None:
         """登录并保存返回的 token"""


### PR DESCRIPTION
## Summary
- extend debugging output in REST client and SQL parsing
- log parsing steps when creating tables and importing CSV
- show arguments and initialization details in CLI
- document `--debug` flag in README

## Testing
- `yarn test` *(fails: package missing in lockfile)*
- `PYTHONPATH=pytools python -m nocobase_api --help`

------
https://chatgpt.com/codex/tasks/task_e_685cc6c480b4832d8ed0b6125e2e223a