### PR TITLE
Enable field type selection for main data source

### DIFF
--- a/packages/core/client/src/collection-manager/Configuration/EditFieldAction.tsx
+++ b/packages/core/client/src/collection-manager/Configuration/EditFieldAction.tsx
@@ -40,6 +40,15 @@ const getSchema = (
   if (properties?.name) {
     properties.name['x-disabled'] = true;
   }
+  if (record?.possibleTypes) {
+    properties.type = {
+      type: 'string',
+      title: '{{t("Field type")}}',
+      'x-decorator': 'FormItem',
+      'x-component': 'Select',
+      enum: record.possibleTypes.map((v) => ({ label: v, value: v })),
+    };
+  }
 
   return {
     type: 'object',

--- a/packages/plugins/@nocobase/plugin-data-source-main/src/server/resourcers/collections.ts
+++ b/packages/plugins/@nocobase/plugin-data-source-main/src/server/resourcers/collections.ts
@@ -7,7 +7,7 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
-import { Database } from '@nocobase/database';
+import { Database, ViewFieldInference } from '@nocobase/database';
 import lodash from 'lodash';
 
 export default {
@@ -31,9 +31,14 @@ export default {
 
       obj.fields = lodash.sortBy(
         [...collection.fields.values()].map((field) => {
-          return {
-            ...field.options,
-          };
+          const options = { ...field.options };
+          const infer = ViewFieldInference.inferToFieldType({
+            dialect: db.sequelize.getDialect(),
+            name: field.name,
+            type: field.typeToString(),
+          });
+          Object.assign(options, infer);
+          return options;
         }),
         '__sort',
       );


### PR DESCRIPTION
## Summary
- expose possible field types when listing collections
- return possible field types for main data source field APIs
- allow editing field type in EditFieldAction drawer

## Testing
- `yarn lint` *(fails: package not present in lockfile)*
- `yarn test` *(fails: package not present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_685e4e39471c832d87fc56b2c2c82c87