### PR TITLE
Enable field type configuration

### DIFF
--- a/packages/core/client/src/collection-manager/Configuration/AddFieldAction.tsx
+++ b/packages/core/client/src/collection-manager/Configuration/AddFieldAction.tsx
@@ -168,6 +168,7 @@ export const AddFieldAction = (props) => {
   const [visible, setVisible] = useState(false);
   const [targetScope, setTargetScope] = useState();
   const [schema, setSchema] = useState({});
+  const [fieldTypeOptions, setFieldTypeOptions] = useState<any[]>([]);
   const compile = useCompile();
   const { t } = useTranslation();
   const { isDialect } = useDialect();
@@ -283,8 +284,10 @@ export const AddFieldAction = (props) => {
         //@ts-ignore
         const targetScope = e.item.props['data-targetScope'];
         targetScope && setTargetScope(targetScope);
-        const schema = getSchema(getInterface(e.key), record, compile);
+        const iface = getInterface(e.key);
+        const schema = getSchema(iface, record, compile);
         if (schema) {
+          setFieldTypeOptions(iface?.getAvailableOptions?.() || []);
           setSchema(schema);
           setVisible(true);
         }
@@ -333,6 +336,7 @@ export const AddFieldAction = (props) => {
               isDialect,
               disabledJSONB: false,
               scopeKeyOptions,
+              fieldTypeOptions,
               createMainOnly: true,
               editMainOnly: true,
               ...scope,

--- a/packages/core/client/src/collection-manager/Configuration/EditFieldAction.tsx
+++ b/packages/core/client/src/collection-manager/Configuration/EditFieldAction.tsx
@@ -143,6 +143,7 @@ export const EditFieldAction = (props) => {
   const { getInterface, collections, getCollection } = useCollectionManager_deprecated();
   const [visible, setVisible] = useState(false);
   const [schema, setSchema] = useState({});
+  const [fieldTypeOptions, setFieldTypeOptions] = useState<any[]>([]);
   const api = useAPIClient();
   const { t } = useTranslation();
   const compile = useCompile();
@@ -197,6 +198,7 @@ export const EditFieldAction = (props) => {
               defaultValues.autoCreateReverseField = true;
             }
             const schema = getSchema(interfaceConf, defaultValues, record, compile, getContainer);
+            setFieldTypeOptions(interfaceConf?.getAvailableOptions?.() || []);
             setSchema(schema);
             setVisible(true);
           }}
@@ -216,6 +218,7 @@ export const EditFieldAction = (props) => {
             isDialect,
             disabledJSONB: true,
             scopeKeyOptions,
+            fieldTypeOptions,
             createMainOnly: false,
             ...scope,
           }}

--- a/packages/core/client/src/collection-manager/interfaces/input.ts
+++ b/packages/core/client/src/collection-manager/interfaces/input.ts
@@ -52,11 +52,15 @@ export class InputFieldInterface extends CollectionFieldInterface {
   sortable = true;
   default = {
     interface: 'input',
+    fieldType: 'string',
     type: 'string',
     uiSchema: {
       type: 'string',
       'x-component': 'Input',
     },
+  };
+  availableOptions = {
+    string: ['string', 'uid'],
   };
   availableTypes = ['string', 'uid'];
   hasDefaultValue = true;

--- a/packages/core/client/src/collection-manager/interfaces/integer.ts
+++ b/packages/core/client/src/collection-manager/interfaces/integer.ts
@@ -25,6 +25,7 @@ export class IntegerFieldInterface extends CollectionFieldInterface {
   title = '{{t("Integer")}}';
   sortable = true;
   default = {
+    fieldType: 'bigInt',
     type: 'bigInt',
     uiSchema: {
       type: 'number',
@@ -35,6 +36,9 @@ export class IntegerFieldInterface extends CollectionFieldInterface {
       },
       'x-validator': 'integer',
     },
+  };
+  availableOptions = {
+    number: ['bigInt', 'integer', 'sort'],
   };
   availableTypes = ['bigInt', 'integer', 'sort'];
   hasDefaultValue = true;

--- a/packages/core/client/src/collection-manager/interfaces/properties/index.ts
+++ b/packages/core/client/src/collection-manager/interfaces/properties/index.ts
@@ -533,6 +533,16 @@ export const defaultProps = {
     description:
       "{{t('Randomly generated and can be modified. Support letters, numbers and underscores, must start with an letter.')}}",
   },
+  fieldType: {
+    type: 'string',
+    title: '{{t("Field type")}}',
+    'x-disabled': '{{ createOnly }}',
+    'x-decorator': 'FormItem',
+    'x-component': 'Cascader',
+    'x-component-props': {
+      options: '{{ fieldTypeOptions }}',
+    },
+  },
 };
 
 export const recordPickerViewer = {

--- a/packages/core/client/src/collection-manager/interfaces/textarea.ts
+++ b/packages/core/client/src/collection-manager/interfaces/textarea.ts
@@ -20,11 +20,15 @@ export class TextareaFieldInterface extends CollectionFieldInterface {
   title = '{{t("Long text")}}';
   default = {
     interface: 'textarea',
+    fieldType: 'text',
     type: 'text',
     uiSchema: {
       type: 'string',
       'x-component': 'Input.TextArea',
     },
+  };
+  availableOptions = {
+    text: ['text', 'json', 'string'],
   };
   availableTypes = ['text', 'json', 'string'];
   hasDefaultValue = true;

--- a/packages/core/client/src/data-source/collection-field-interface/CollectionFieldInterface.ts
+++ b/packages/core/client/src/data-source/collection-field-interface/CollectionFieldInterface.ts
@@ -38,6 +38,7 @@ export abstract class CollectionFieldInterface {
   };
   sortable?: boolean;
   availableTypes?: string[];
+  availableOptions?: Record<string, string[]>;
   supportDataSourceType?: string[];
   notSupportDataSourceType?: string[];
   hasDefaultValue?: boolean;
@@ -160,6 +161,25 @@ export abstract class CollectionFieldInterface {
         ],
       },
     };
+  }
+
+  getAllAvailableTypes() {
+    const optionTypes = Object.values(this.availableOptions || {}).flat();
+    return Array.from(new Set([...(this.availableTypes || []), ...optionTypes]));
+  }
+
+  getAvailableOptions() {
+    return Object.entries(this.availableOptions || {}).map(([key, values]) => ({
+      label: key,
+      value: key,
+      children: values.map((v) => ({ label: v, value: v })),
+    }));
+  }
+
+  validateFieldDataType(type: string) {
+    const all = this.getAllAvailableTypes();
+    if (all.length === 0) return true;
+    return all.includes(type);
   }
 
   addOperator(operatorOption: any) {

--- a/packages/plugins/@nocobase/plugin-data-source-manager/src/client/component/CollectionsManager/AddFieldAction.tsx
+++ b/packages/plugins/@nocobase/plugin-data-source-manager/src/client/component/CollectionsManager/AddFieldAction.tsx
@@ -209,6 +209,7 @@ const AddFieldAction = (props) => {
   const [visible, setVisible] = useState(false);
   const [targetScope, setTargetScope] = useState();
   const [schema, setSchema] = useState({});
+  const [fieldTypeOptions, setFieldTypeOptions] = useState<any[]>([]);
   const compile = useCompile();
   const { t } = useTranslation();
   const {
@@ -312,8 +313,10 @@ const AddFieldAction = (props) => {
         //@ts-ignore
         const targetScope = e.item.props['data-targetScope'];
         targetScope && setTargetScope(targetScope);
-        const schema = getSchema(getInterface(e.key), record, compile);
+        const iface = getInterface(e.key);
+        const schema = getSchema(iface, record, compile);
         if (schema) {
+          setFieldTypeOptions(iface?.getAvailableOptions?.() || []);
           setSchema(schema);
           setVisible(true);
         }
@@ -348,6 +351,7 @@ const AddFieldAction = (props) => {
               collections: currentCollections,
               isDialect,
               disabledJSONB: false,
+              fieldTypeOptions,
               createMainOnly: true,
               ...scope,
             }}

--- a/packages/plugins/@nocobase/plugin-data-source-manager/src/client/component/CollectionsManager/EditFieldAction.tsx
+++ b/packages/plugins/@nocobase/plugin-data-source-manager/src/client/component/CollectionsManager/EditFieldAction.tsx
@@ -195,6 +195,7 @@ const EditFieldAction = (props) => {
   };
   const [visible, setVisible] = useState(false);
   const [schema, setSchema] = useState({});
+  const [fieldTypeOptions, setFieldTypeOptions] = useState<any[]>([]);
   const api = useAPIClient();
   const { t } = useTranslation();
   const compile = useCompile();
@@ -252,6 +253,7 @@ const EditFieldAction = (props) => {
               compile,
               getContainer,
             });
+            setFieldTypeOptions(interfaceConf?.getAvailableOptions?.() || []);
             setSchema(schema);
             setVisible(true);
           }}
@@ -269,6 +271,7 @@ const EditFieldAction = (props) => {
             collections: currentCollections,
             isDialect,
             scopeKeyOptions,
+            fieldTypeOptions,
             disabledJSONB: true,
             ...scope,
             createOnly: false,

--- a/packages/plugins/@nocobase/plugin-data-source-manager/src/client/component/MainDataSourceManager/Configuration/CollectionFields.tsx
+++ b/packages/plugins/@nocobase/plugin-data-source-manager/src/client/component/MainDataSourceManager/Configuration/CollectionFields.tsx
@@ -35,7 +35,7 @@ import {
   useResourceContext,
   ViewCollectionField,
 } from '@nocobase/client';
-import { message, Space, Switch, Table, TableColumnProps, Tag, Tooltip } from 'antd';
+import { message, Space, Switch, Table, TableColumnProps, Tag, Tooltip, Cascader } from 'antd';
 import React, { createContext, useContext, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -98,6 +98,10 @@ const tableContainer = css`
   }
 `;
 
+const createFieldTypeOptions = (getInterface, ifaceName: string) => {
+  return getInterface(ifaceName)?.getAvailableOptions?.() || [];
+};
+
 const titlePrompt = 'Default title for each record';
 const CurrentFields = (props) => {
   const compile = useCompile();
@@ -121,6 +125,35 @@ const CurrentFields = (props) => {
     {
       dataIndex: 'name',
       title: t('Field name'),
+    },
+    {
+      dataIndex: 'type',
+      title: t('Field type'),
+      render: (value, record) => {
+        const options = createFieldTypeOptions(getInterface, record.interface);
+        return record.possibleTypes ? (
+          <Cascader
+            size="small"
+            options={options}
+            defaultValue={[record.fieldType || value]}
+            onChange={async (_, [type]) => {
+              setLoadingRecord(record);
+              await api.request({
+                url: `collections.fields:update?filterByTk=${record.name}`,
+                method: 'post',
+                data: { type },
+              });
+              ctx?.refresh?.();
+              await props.refreshAsync();
+              setLoadingRecord(null);
+              refreshCM();
+              message.success(t('Saved successfully'));
+            }}
+          />
+        ) : (
+          <Tag>{value}</Tag>
+        );
+      },
     },
     {
       dataIndex: 'interface',
@@ -238,6 +271,35 @@ const InheritFields = (props) => {
     {
       dataIndex: 'name',
       title: t('Field name'),
+    },
+    {
+      dataIndex: 'type',
+      title: t('Field type'),
+      render: (value, record) => {
+        const options = createFieldTypeOptions(getInterface, record.interface);
+        return record.possibleTypes ? (
+          <Cascader
+            size="small"
+            options={options}
+            defaultValue={[record.fieldType || value]}
+            onChange={async (_, [type]) => {
+              setLoadingRecord(record);
+              await api.request({
+                url: `collections.fields:update?filterByTk=${record.name}`,
+                method: 'post',
+                data: { type },
+              });
+              ctx?.refresh?.();
+              await props.refreshAsync();
+              setLoadingRecord(null);
+              refreshCM();
+              message.success(t('Saved successfully'));
+            }}
+          />
+        ) : (
+          <Tag>{value}</Tag>
+        );
+      },
     },
     {
       dataIndex: 'interface',


### PR DESCRIPTION
## Summary
- allow interfaces to define field type options
- support cascader field type selector in configuration forms
- expose utilities for checking available types
- allow changing field types in data source manager UI

## Testing
- `yarn lint` *(fails: This package doesn't seem to be present in your lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_685e597b8638832da9213155230e5108