### PR TITLE
Add JSON table config support to pytools

### DIFF
--- a/pytools/README.md
+++ b/pytools/README.md
@@ -1,7 +1,7 @@
 # NocoBase Python 工具
 
 该目录提供了一套使用 Python 调用 NocoBase REST API 的简单脚本，
-可以根据 SQL 文件创建集合，并将 CSV 数据导入到指定集合中。
+可以根据 SQL 或 JSON 文件创建集合，并将 CSV 数据导入到指定集合中。
 
 ## 使用方法
 
@@ -13,6 +13,7 @@ python -m nocobase_api --base-url http://localhost:13000/api \
     --username admin --password secret \
     --authenticator goout \
     --sql schema.sql \
+    --json schema.json \
     --csv data.csv --collection posts \
     --debug
 ```
@@ -26,11 +27,12 @@ python -m nocobase_api --base-url http://localhost:13000/api \
 - `--authenticator`：登录方式标识，默认为 `basic`，根据后台配置选择
   `goout` 等值。
 - `--sql`：包含 `CREATE TABLE` 语句的 SQL 文件，可根据其中定义创建集合。
+- `--json`：包含集合定义的 JSON 文件，可批量创建集合及字段。
 - `--csv`：要导入的 CSV 文件。
 - `--collection`：CSV 数据要导入的集合名称。
 - `--debug`：输出调试信息，便于排查脚本执行过程中的问题。
 
-根据需要选择参数：只创建集合时只需提供 `--sql`；仅导入数据时需要同时指定 `--csv` 与 `--collection`。
+根据需要选择参数：只创建集合时可提供 `--sql` 或 `--json`；仅导入数据时需要同时指定 `--csv` 与 `--collection`。
 
 运行成功后脚本会依次创建集合并导入数据，方便在 NocoBase 中快速初始化测试数据。
 

--- a/pytools/nocobase_api/__init__.py
+++ b/pytools/nocobase_api/__init__.py
@@ -1,7 +1,8 @@
 """NocoBase Python 工具包
 
-提供简易的 API 客户端及 SQL 解析函数。"""
+提供简易的 API 客户端及 SQL、JSON 解析函数。"""
 
 from .client import NocoBaseClient
 from .sql_utils import parse_sql_file
+from .json_utils import parse_json_file
 

--- a/pytools/nocobase_api/__main__.py
+++ b/pytools/nocobase_api/__main__.py
@@ -1,7 +1,7 @@
 import argparse
 import logging
 from .client import NocoBaseClient
-from .bulk_tools import create_tables_from_sql, import_csv
+from .bulk_tools import create_tables_from_sql, import_csv, create_tables_from_json
 
 """NocoBase 命令行工具
 
@@ -22,6 +22,7 @@ def main():
         help="登录方式标识，例如 basic/goout",
     )
     # 选项：指定 SQL 文件创建数据表
+    parser.add_argument("--json", help="包含集合定义的 JSON 文件")
     parser.add_argument("--sql", help="包含建表语句的 SQL 文件")
     # 选项：导入 CSV 数据及对应集合名称
     parser.add_argument("--csv", help="要导入的 CSV 文件")
@@ -49,6 +50,10 @@ def main():
     # 登录以获取 token
     client.sign_in()
     logging.info("Signed in successfully")
+
+    if args.json:
+        logging.info("Creating collections from %s", args.json)
+        create_tables_from_json(client, args.json)
 
     if args.sql:
         # 根据 SQL 文件创建数据表

--- a/pytools/nocobase_api/bulk_tools.py
+++ b/pytools/nocobase_api/bulk_tools.py
@@ -2,6 +2,7 @@ import csv
 import logging
 from .client import NocoBaseClient
 from .sql_utils import parse_sql_file
+from .json_utils import parse_json_file
 
 """批量操作工具函数
 
@@ -32,3 +33,16 @@ def import_csv(client: NocoBaseClient, collection: str, csv_path: str):
             logging.debug("Creating record: %s", row)
             client.create_record(collection, row)
 
+
+
+def create_tables_from_json(client: NocoBaseClient, json_path: str):
+    """根据 JSON 文件创建集合和字段"""
+    logging.debug("Parsing JSON file %s", json_path)
+    tables = parse_json_file(json_path)
+    logging.debug("Tables to create: %s", tables)
+    for table in tables:
+        logging.info("Creating collection %s", table.get("name"))
+        client.create_collection(table.get("name"))
+        for field in table.get("fields", []):
+            logging.info("Creating field %s.%s", table.get("name"), field.get("name"))
+            client.create_field(table.get("name"), field)

--- a/pytools/nocobase_api/json_utils.py
+++ b/pytools/nocobase_api/json_utils.py
@@ -1,0 +1,15 @@
+import json
+import logging
+from typing import List, Dict, Any
+
+"""JSON 辅助函数，用于解析集合定义"""
+
+
+def parse_json_file(path: str) -> List[Dict[str, Any]]:
+    """解析 JSON 文件，返回集合及字段信息"""
+    logging.debug("Reading JSON file: %s", path)
+    with open(path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    tables = data.get("tables", [])
+    logging.debug("Tables loaded: %s", tables)
+    return tables

--- a/pytools/sample_schema.json
+++ b/pytools/sample_schema.json
@@ -1,0 +1,22 @@
+{
+  "tables": [
+    {
+      "name": "posts",
+      "fields": [
+        {
+          "title": "标题",
+          "name": "title",
+          "type": "string",
+          "isTitle": true,
+          "description": "文章标题"
+        },
+        {
+          "title": "内容",
+          "name": "content",
+          "type": "text",
+          "description": "正文"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- support parsing JSON table definitions
- expose `parse_json_file`
- allow `--json` flag in CLI
- update docs and sample file

## Testing
- `yarn lint` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68601c422480832d9e5ab1cf80d95b47