### PR TITLE
Fix pytools field creation

### DIFF
--- a/pytools/README.md
+++ b/pytools/README.md
@@ -32,6 +32,9 @@ python -m nocobase_api --base-url http://localhost:13000/api \
 - `--collection`：CSV 数据要导入的集合名称。
 - `--debug`：输出调试信息，便于排查脚本执行过程中的问题。
 
+在 JSON 文件中可以为字段设置诸如 `title`、`required`、`unique` 以及
+`primaryKey` 等属性，脚本会原样传递这些配置以创建相应字段。
+
 根据需要选择参数：只创建集合时可提供 `--sql` 或 `--json`；仅导入数据时需要同时指定 `--csv` 与 `--collection`。
 
 运行成功后脚本会依次创建集合并导入数据，方便在 NocoBase 中快速初始化测试数据。

--- a/pytools/nocobase_api/client.py
+++ b/pytools/nocobase_api/client.py
@@ -71,12 +71,8 @@ class NocoBaseClient:
 
     def create_field(self, collection_name: str, field: dict) -> dict:
         """在指定集合中创建字段"""
-        values = {
-            "collectionName": collection_name,
-            "name": field.get("name"),
-            "type": field.get("type"),
-            "interface": field.get("interface"),
-        }
+        values = field.copy()
+        values["collectionName"] = collection_name
         return self._request("POST", "fields", data=values)
 
     def create_record(self, collection: str, values: dict) -> dict:


### PR DESCRIPTION
## Summary
- handle full field definitions when creating fields
- document JSON field options in README

## Testing
- `python -m pytools.nocobase_api --help`
- `yarn test` *(fails: package missing, network restrictions)*
- `yarn install` *(fails: 403 fetching deps)*

------
https://chatgpt.com/codex/tasks/task_e_68615babcde4832d95c4c77612887525