### PR TITLE
Improve JSON table creation logging

### DIFF
--- a/pytools/README.md
+++ b/pytools/README.md
@@ -34,8 +34,11 @@ python -m nocobase_api --base-url http://localhost:13000/api \
 - `--collection`：CSV 数据要导入的集合名称。
 - `--debug`：输出调试信息，便于排查脚本执行过程中的问题。
 
-在 JSON 文件中可以为字段设置诸如 `title`、`required`、`unique` 以及
+在 JSON 文件中可以为字段设置诸如 `title`、`required`、`unique`、
 `primaryKey` 等属性，脚本会原样传递这些配置以创建相应字段。
+JSON 根节点既可以是集合数组，也可以包含 `tables` 或 `collections`
+字段，脚本都会自动识别。
+在执行命令时附加 `--debug` 参数即可看到完整的请求与响应，便于调试。
 
 根据需要选择参数：只创建集合时可提供 `--sql` 或 `--json`；仅导入数据时需要同时指定 `--csv` 与 `--collection`。
 

--- a/pytools/nocobase_api/bulk_tools.py
+++ b/pytools/nocobase_api/bulk_tools.py
@@ -40,9 +40,15 @@ def create_tables_from_json(client: NocoBaseClient, json_path: str):
     logging.debug("Parsing JSON file %s", json_path)
     tables = parse_json_file(json_path)
     logging.debug("Tables to create: %s", tables)
+
     for table in tables:
-        logging.info("Creating collection %s", table.get("name"))
-        client.create_collection(table.get("name"))
+        collection_name = table.get("name")
+        logging.info("Creating collection %s", collection_name)
+        resp = client.create_collection(collection_name)
+        logging.debug("Collection response: %s", resp)
+
         for field in table.get("fields", []):
-            logging.info("Creating field %s.%s", table.get("name"), field.get("name"))
-            client.create_field(table.get("name"), field)
+            field_name = field.get("name")
+            logging.info("Creating field %s.%s", collection_name, field_name)
+            field_resp = client.create_field(collection_name, field)
+            logging.debug("Field response: %s", field_resp)

--- a/pytools/nocobase_api/json_utils.py
+++ b/pytools/nocobase_api/json_utils.py
@@ -10,6 +10,13 @@ def parse_json_file(path: str) -> List[Dict[str, Any]]:
     logging.debug("Reading JSON file: %s", path)
     with open(path, "r", encoding="utf-8") as f:
         data = json.load(f)
-    tables = data.get("tables", [])
+
+    # 既支持以列表为根节点的格式，也兼容常见的 `tables` 或 `collections` 键
+    tables: List[Dict[str, Any]]
+    if isinstance(data, list):
+        tables = data
+    else:
+        tables = data.get("tables") or data.get("collections") or []
+
     logging.debug("Tables loaded: %s", tables)
     return tables


### PR DESCRIPTION
## Summary
- handle `tables` or `collections` keys in JSON parser
- add verbose logging while creating collections and fields
- document JSON root formats and debug option in README

## Testing
- `yarn test` *(fails: RequestError 403 during yarn install)*

------
https://chatgpt.com/codex/tasks/task_e_6861684c4e44832daa05d85d5d3490ad