### PR TITLE
Improve debug in NocoBase API tools

### DIFF
--- a/pytools/README.md
+++ b/pytools/README.md
@@ -39,6 +39,8 @@ python -m nocobase_api --base-url http://localhost:13000/api \
 JSON 根节点既可以是集合数组，也可以包含 `tables` 或 `collections`
 字段，脚本都会自动识别。
 在执行命令时附加 `--debug` 参数即可看到完整的请求与响应，便于调试。
+开启调试后，每创建一个字段都会立即请求并输出该集合当前的字段列表，
+可快速验证字段是否真正保存成功。
 
 根据需要选择参数：只创建集合时可提供 `--sql` 或 `--json`；仅导入数据时需要同时指定 `--csv` 与 `--collection`。
 

--- a/pytools/nocobase_api/bulk_tools.py
+++ b/pytools/nocobase_api/bulk_tools.py
@@ -21,6 +21,8 @@ def create_tables_from_sql(client: NocoBaseClient, sql_path: str):
         for field in table["fields"]:
             logging.info("Creating field %s.%s", table["name"], field["name"])
             client.create_field(table["name"], field)
+            fields_after = client.list_fields(table["name"])
+            logging.debug("Fields of %s after creation: %s", table["name"], fields_after)
 
 
 def import_csv(client: NocoBaseClient, collection: str, csv_path: str):
@@ -52,3 +54,6 @@ def create_tables_from_json(client: NocoBaseClient, json_path: str):
             logging.info("Creating field %s.%s", collection_name, field_name)
             field_resp = client.create_field(collection_name, field)
             logging.debug("Field response: %s", field_resp)
+            # 创建后立即列出字段，便于确认是否成功保存
+            fields_after = client.list_fields(collection_name)
+            logging.debug("Fields of %s after creation: %s", collection_name, fields_after)

--- a/pytools/nocobase_api/client.py
+++ b/pytools/nocobase_api/client.py
@@ -75,7 +75,14 @@ class NocoBaseClient:
         values = field.copy()
         # 接口要求将集合名称包含在路径中
         path = f"collections/{collection_name}/fields:create"
-        return self._request("POST", path, data=values)
+        resp = self._request("POST", path, data=values)
+        logging.debug("Field created response: %s", resp)
+        return resp
+
+    def list_fields(self, collection_name: str) -> dict:
+        """列出指定集合的字段"""
+        path = f"collections/{collection_name}/fields:list"
+        return self._request("GET", path)
 
     def create_record(self, collection: str, values: dict) -> dict:
         """在指定集合中创建记录"""


### PR DESCRIPTION
## Summary
- add `list_fields` method to NocoBaseClient
- log created field responses and show current field list
- document enhanced debug output in pytools README

## Testing
- `yarn lint` *(fails: package not in lockfile)*
- `yarn install` *(fails: RequestError 403)*

------
https://chatgpt.com/codex/tasks/task_e_68616b370c78832d9e6bfbca28bbf4b4