### PR TITLE
Refresh NocoBase data source via Python tools

### DIFF
--- a/pytools/README.md
+++ b/pytools/README.md
@@ -33,6 +33,8 @@ python -m nocobase_api --base-url http://localhost:13000/api \
 - `--csv`：要导入的 CSV 文件。
 - `--collection`：CSV 数据要导入的集合名称。
 - `--debug`：输出调试信息，便于排查脚本执行过程中的问题。
+- `--refresh`：创建或导入完成后刷新数据源，使界面立刻反映最新结构，
+  默认启用，可使用 `--no-refresh` 关闭。
 
 在 JSON 文件中可以为字段设置诸如 `title`、`required`、`unique`、
 `primaryKey` 等属性，脚本会原样传递这些配置以创建相应字段。
@@ -45,4 +47,8 @@ JSON 根节点既可以是集合数组，也可以包含 `tables` 或 `collectio
 根据需要选择参数：只创建集合时可提供 `--sql` 或 `--json`；仅导入数据时需要同时指定 `--csv` 与 `--collection`。
 
 运行成功后脚本会依次创建集合并导入数据，方便在 NocoBase 中快速初始化测试数据。
+
+完成数据表及字段的创建后，需要调用 `dataSources:refresh` 接口刷新数据源，
+否则在 NocoBase UI 中可能无法立即看到新的集合或字段。命令行工具默认
+会在操作结束后自动执行该步骤。
 

--- a/pytools/nocobase_api/__main__.py
+++ b/pytools/nocobase_api/__main__.py
@@ -32,6 +32,12 @@ def main():
         action="store_true",
         help="输出调试信息",
     )
+    parser.add_argument(
+        "--refresh",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="执行完操作后刷新数据源，默认启用 (可用 --no-refresh 禁用)",
+    )
     args = parser.parse_args()
 
     logging.basicConfig(
@@ -64,6 +70,10 @@ def main():
         # 将 CSV 文件中的记录导入指定集合
         logging.info("Importing %s into %s", args.csv, args.collection)
         import_csv(client, args.collection, args.csv)
+
+    if args.refresh:
+        logging.info("Refreshing data source")
+        client.refresh_data_source()
 
 
 if __name__ == "__main__":

--- a/pytools/nocobase_api/bulk_tools.py
+++ b/pytools/nocobase_api/bulk_tools.py
@@ -24,6 +24,8 @@ def create_tables_from_sql(client: NocoBaseClient, sql_path: str):
             fields_after = client.list_fields(table["name"])
             logging.debug("Fields of %s after creation: %s", table["name"], fields_after)
 
+    client.refresh_data_source("main")
+
 
 def import_csv(client: NocoBaseClient, collection: str, csv_path: str):
     """将 CSV 数据导入指定集合"""
@@ -57,3 +59,5 @@ def create_tables_from_json(client: NocoBaseClient, json_path: str):
             # 创建后立即列出字段，便于确认是否成功保存
             fields_after = client.list_fields(collection_name)
             logging.debug("Fields of %s after creation: %s", collection_name, fields_after)
+
+    client.refresh_data_source("main")

--- a/pytools/nocobase_api/client.py
+++ b/pytools/nocobase_api/client.py
@@ -89,3 +89,9 @@ class NocoBaseClient:
         path = f"{collection}:create"
         return self._request("POST", path, data={"values": values})
 
+    def refresh_data_source(self, key: str = "main") -> dict:
+        """刷新指定数据源，使最新结构在界面中可见"""
+        quoted = urllib.parse.quote(key, safe="")
+        path = f"dataSources:refresh?filterByTk={quoted}"
+        return self._request("POST", path)
+


### PR DESCRIPTION
## Summary
- add `refresh_data_source` method to Python API client
- refresh data sources when creating tables from JSON/SQL
- expose `--refresh/--no-refresh` flag in CLI
- document data source refresh requirement in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68616e68784c832d912de4af48e9f407