### PR TITLE
Add data source field support to pytools

### DIFF
--- a/pytools/README.md
+++ b/pytools/README.md
@@ -2,8 +2,10 @@
 
 该目录提供了一套使用 Python 调用 NocoBase REST API 的简单脚本，
 可以根据 SQL 或 JSON 文件创建集合，并将 CSV 数据导入到指定集合中。
-创建集合和字段时使用的是最新的接口路径，如 `collections:create`
-和 `collections/<collection>/fields:create`。
+创建集合时使用 `collections:create`，字段默认通过
+`collections/<collection>/fields:create` 创建。如指定 `--data-source`
+参数，则字段会改为调用 `dataSourcesCollections/<dataSource>.<collection>/fields:create`
+以确保在数据源管理界面同步显示。
 
 ## 使用方法
 
@@ -32,6 +34,7 @@ python -m nocobase_api --base-url http://localhost:13000/api \
 - `--json`：包含集合定义的 JSON 文件，可批量创建集合及字段。
 - `--csv`：要导入的 CSV 文件。
 - `--collection`：CSV 数据要导入的集合名称。
+- `--data-source`：指定数据源 key（例如 `main`），创建字段时将写入该数据源。
 - `--debug`：输出调试信息，便于排查脚本执行过程中的问题。
 - `--refresh`：创建或导入完成后刷新数据源，使界面立刻反映最新结构，
   默认启用，可使用 `--no-refresh` 关闭。

--- a/pytools/nocobase_api/__main__.py
+++ b/pytools/nocobase_api/__main__.py
@@ -28,6 +28,11 @@ def main():
     parser.add_argument("--csv", help="要导入的 CSV 文件")
     parser.add_argument("--collection", help="CSV 数据对应的集合名称")
     parser.add_argument(
+        "--data-source",
+        default="main",
+        help="数据源 key，默认为 main，与后台数据源管理中的 key 保持一致",
+    )
+    parser.add_argument(
         "--debug",
         action="store_true",
         help="输出调试信息",
@@ -59,12 +64,12 @@ def main():
 
     if args.json:
         logging.info("Creating collections from %s", args.json)
-        create_tables_from_json(client, args.json)
+        create_tables_from_json(client, args.json, data_source_key=args.data_source)
 
     if args.sql:
         # 根据 SQL 文件创建数据表
         logging.info("Creating collections from %s", args.sql)
-        create_tables_from_sql(client, args.sql)
+        create_tables_from_sql(client, args.sql, data_source_key=args.data_source)
 
     if args.csv and args.collection:
         # 将 CSV 文件中的记录导入指定集合
@@ -73,7 +78,7 @@ def main():
 
     if args.refresh:
         logging.info("Refreshing data source")
-        client.refresh_data_source()
+        client.refresh_data_source(args.data_source)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- allow specifying a data source when creating collections/fields
- create fields via `dataSourcesCollections` when `--data-source` is set
- expose `--data-source` flag on the CLI
- document the new option in `pytools/README.md`

## Testing
- `python -m pytools.nocobase_api --help | head`

------
https://chatgpt.com/codex/tasks/task_e_686170e2eb6c832d8479a44cca4a281b