### PR TITLE
Fix missing fields in main datasource view

### DIFF
--- a/packages/plugins/@nocobase/plugin-data-source-manager/src/server/resourcers/data-sources-collections-fields.ts
+++ b/packages/plugins/@nocobase/plugin-data-source-manager/src/server/resourcers/data-sources-collections-fields.ts
@@ -59,6 +59,15 @@ export default {
       if (values.possibleTypes) {
         delete values.possibleTypes;
       }
+      const collectionRecord = await mainDb.getRepository('dataSourcesCollections').findOne({
+        filter: {
+          name: collectionName,
+          dataSourceKey,
+        },
+      });
+
+      const collectionKey = collectionRecord?.get('key');
+
       if (!fieldRecord) {
         fieldRecord = await mainDb.getRepository('dataSourcesFields').create({
           values: {
@@ -66,6 +75,7 @@ export default {
             name,
             collectionName: collectionName,
             dataSourceKey,
+            collectionKey,
           },
         });
       } else {
@@ -76,7 +86,10 @@ export default {
               collectionName,
               dataSourceKey,
             },
-            values,
+            values: {
+              ...values,
+              collectionKey,
+            },
           })
         )[0];
       }
@@ -114,11 +127,19 @@ export default {
       if (values.possibleTypes) {
         delete values.possibleTypes;
       }
+      const collectionRecord = await mainDb.getRepository('dataSourcesCollections').findOne({
+        filter: {
+          name: collectionName,
+          dataSourceKey,
+        },
+      });
+
       const fieldRecord = await mainDb.getRepository('dataSourcesFields').create({
         values: {
           ...values,
           collectionName,
           dataSourceKey,
+          collectionKey: collectionRecord?.get('key'),
         },
       });
 


### PR DESCRIPTION
## Summary
- link uploaded datasource fields to their collections via `collectionKey`

## Testing
- `yarn test` *(fails: package missing in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68620d824c2c832db8deb993850aa8bc