### PR TITLE
Fix missing introspection options when adding data sources

### DIFF
--- a/packages/plugins/@nocobase/plugin-data-source-manager/src/server/plugin.ts
+++ b/packages/plugins/@nocobase/plugin-data-source-manager/src/server/plugin.ts
@@ -373,7 +373,7 @@ export class PluginDataSourceManagerServer extends Plugin {
           if (actionName === 'add') {
             const klass = dataSourceManager.factory.getClass(values.options.type);
             // @ts-ignore
-            const dataSource = new klass(dbOptions);
+            const dataSource = new klass(values.options);
             introspector = dataSource.collectionManager.dataSource.createDatabaseIntrospector(
               dataSource.collectionManager.db,
             );


### PR DESCRIPTION
## Summary
- fix data source manager plugin to use the actual options when initializing a data source

## Testing
- `yarn install` *(fails: RequestError 403)*
- `yarn test` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68620d96270c832d8d274533ef20f4ce