### PR TITLE
Add Python script example

### DIFF
--- a/examples/index.md
+++ b/examples/index.md
@@ -31,7 +31,8 @@
   - [最简单的测试用例](./app/__tests__/app.test.ts)
 - 客户端 SDK（APIClient）示例
   - [客户端常规请求 —— api.request()](./api-client/api.request.ts)
-  - [客户端资源请求 —— api.resource().action()](./api-client/api.resource.ts)
+- [客户端资源请求 —— api.resource().action()](./api-client/api.resource.ts)
+  - [Python 示例：更新字段类型](./python/update_product_id_field.py)
 
 ## Database
 

--- a/examples/python/update_product_id_field.py
+++ b/examples/python/update_product_id_field.py
@@ -1,0 +1,23 @@
+import requests
+from pytools import memoize
+
+API_URL = 'http://localhost:13000/api'
+COLLECTION = 'product'
+FIELD = 'id'
+
+@memoize()
+def update_field_type():
+    url = f"{API_URL}/collections/{COLLECTION}/fields:update"
+    params = {'filterByTk': FIELD}
+    data = {
+        'values': {
+            'type': 'integer'
+        }
+    }
+    response = requests.post(url, params=params, json=data)
+    response.raise_for_status()
+    return response.json()
+
+if __name__ == '__main__':
+    result = update_field_type()
+    print('Update result:', result)


### PR DESCRIPTION
## Summary
- add a Python example using pytools to update the `product` table's `id` field type via API
- link to the new example in `examples/index.md`

## Testing
- `pip install pytools`


------
https://chatgpt.com/codex/tasks/task_e_68678ffc8b7c832dbab7349d9601b4a7