### PR TITLE
Implement CSV upload utility

### DIFF
--- a/agents/csv_generator.py
+++ b/agents/csv_generator.py
@@ -1,6 +1,8 @@
 import csv
 from typing import Any, Dict, Iterable, List, Optional
 
+from .noco_api import NocoAPI
+
 
 def generate_csv(csv_file_path: str, field_names: List[str], records: Iterable[Dict[str, Any]], image_field: Optional[str] = None, image_url: Optional[str] = None) -> None:
     """Generate a CSV file from records.
@@ -26,4 +28,21 @@ def generate_csv(csv_file_path: str, field_names: List[str], records: Iterable[D
             if image_field and image_url:
                 row[image_field] = image_url
             writer.writerow(row)
+
+
+def generate_template(csv_file_path: str, collection_name: str, api: NocoAPI) -> None:
+    """Generate an empty CSV template for a collection.
+
+    Parameters
+    ----------
+    csv_file_path: str
+        Output CSV file path.
+    collection_name: str
+        Name of the collection to inspect for fields.
+    api: NocoAPI
+        Authenticated API client used to fetch field information.
+    """
+    fields = api.list_fields(collection_name)
+    field_names = [field["name"] for field in fields]
+    generate_csv(csv_file_path, field_names, [])
 

--- a/agents/data_uploader.py
+++ b/agents/data_uploader.py
@@ -1,0 +1,23 @@
+import csv
+from typing import Any, Dict
+
+from .noco_api import NocoAPI
+
+
+def upload_csv_data(csv_file_path: str, collection_name: str, api: NocoAPI) -> None:
+    """Upload records from a CSV file to a NocoBase collection.
+
+    Parameters
+    ----------
+    csv_file_path: str
+        Path to the CSV file containing records.
+    collection_name: str
+        Name of the collection to upload records to.
+    api: NocoAPI
+        Authenticated API client.
+    """
+    with open(csv_file_path, newline="", encoding="utf-8") as csvfile:
+        reader = csv.DictReader(csvfile)
+        for row in reader:
+            api.create_record(collection_name, row)
+

--- a/agents/noco_api.py
+++ b/agents/noco_api.py
@@ -35,3 +35,26 @@ class NocoAPI:
         except requests.RequestException as exc:
             raise RuntimeError(f"Failed to list fields: {exc}") from exc
 
+    def create_record(self, collection_name: str, data: Dict[str, Any]) -> Dict[str, Any]:
+        """Create a record in the specified collection.
+
+        Parameters
+        ----------
+        collection_name: str
+            Name of the collection to insert into.
+        data: Dict[str, Any]
+            Record data to create.
+
+        Returns
+        -------
+        Dict[str, Any]
+            Response data from the API.
+        """
+        url = f"{self.api_url}/{collection_name}:create"
+        try:
+            response = requests.post(url, json=data, headers=self._headers())
+            response.raise_for_status()
+            return response.json().get("data", {})
+        except requests.RequestException as exc:
+            raise RuntimeError(f"Failed to create record: {exc}") from exc
+

--- a/main.py
+++ b/main.py
@@ -1,0 +1,42 @@
+import argparse
+
+from agents.auth import authenticate_user
+from agents.noco_api import NocoAPI
+from agents.data_uploader import upload_csv_data
+from agents.csv_generator import generate_template
+
+
+def main() -> None:
+    """Generate templates or upload CSV records to NocoBase collections."""
+    parser = argparse.ArgumentParser(description="NocoBase CSV helper")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    tmpl = sub.add_parser("template", help="Download CSV template")
+    tmpl.add_argument("api_url", help="Base API URL")
+    tmpl.add_argument("username", help="User email for authentication")
+    tmpl.add_argument("password", help="User password")
+    tmpl.add_argument("collection", help="Collection name")
+    tmpl.add_argument("output_csv", help="Path to write the template CSV")
+    tmpl.add_argument("--authenticator", default="local", help="Authenticator name")
+
+    up = sub.add_parser("upload", help="Upload CSV data")
+    up.add_argument("api_url", help="Base API URL")
+    up.add_argument("username", help="User email for authentication")
+    up.add_argument("password", help="User password")
+    up.add_argument("collection", help="Collection name")
+    up.add_argument("csv_file", help="CSV file with records")
+    up.add_argument("--authenticator", default="local", help="Authenticator name")
+
+    args = parser.parse_args()
+
+    token = authenticate_user(args.api_url, args.username, args.password, args.authenticator)
+    api = NocoAPI(args.api_url, token)
+
+    if args.command == "template":
+        generate_template(args.output_csv, args.collection, api)
+    elif args.command == "upload":
+        upload_csv_data(args.csv_file, args.collection, api)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_csv_generator.py
+++ b/tests/test_csv_generator.py
@@ -1,5 +1,6 @@
 import csv
 import os
+from unittest import mock
 
 from agents import csv_generator
 
@@ -15,4 +16,18 @@ def test_generate_csv(tmp_path):
         rows = list(csv.DictReader(f))
 
     assert rows == [{"id": "1", "name": "A", "image": "http://img"}]
+
+
+def test_generate_template(tmp_path):
+    csv_file = tmp_path / "template.csv"
+    api = mock.Mock()
+    api.list_fields.return_value = [{"name": "id"}, {"name": "name"}]
+
+    csv_generator.generate_template(str(csv_file), "posts", api)
+
+    with open(csv_file, newline="", encoding="utf-8") as f:
+        reader = csv.reader(f)
+        headers = next(reader)
+
+    assert headers == ["id", "name"]
 

--- a/tests/test_data_uploader.py
+++ b/tests/test_data_uploader.py
@@ -1,0 +1,23 @@
+from unittest import mock
+import csv
+
+from agents.data_uploader import upload_csv_data
+from agents.noco_api import NocoAPI
+
+
+def test_upload_csv_data(tmp_path):
+    csv_file = tmp_path / "data.csv"
+    with open(csv_file, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=["name"])
+        writer.writeheader()
+        writer.writerow({"name": "A"})
+        writer.writerow({"name": "B"})
+
+    api = NocoAPI("http://api", "token")
+    with mock.patch.object(api, "create_record") as create_record:
+        upload_csv_data(str(csv_file), "posts", api)
+
+    assert create_record.call_count == 2
+    create_record.assert_any_call("posts", {"name": "A"})
+    create_record.assert_any_call("posts", {"name": "B"})
+


### PR DESCRIPTION
## Summary
- add helper to upload CSV records to NocoBase
- support creating records in `NocoAPI`
- test CSV upload helper
- provide CLI `main.py` for uploading records
- generate CSV templates from collection fields

## Testing
- `pip install requests`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f44e96d18832d949d42e133881934