### PR TITLE
Add paginate param for list_fields

### DIFF
--- a/agents/noco_api.py
+++ b/agents/noco_api.py
@@ -29,7 +29,11 @@ class NocoAPI:
         """Return all fields for a given collection."""
         url = f"{self.api_url}/collections/{collection_name}/fields:list"
         try:
-            response = requests.get(url, headers=self._headers())
+            response = requests.get(
+                url,
+                headers=self._headers(),
+                params={"paginate": "false"},
+            )
             response.raise_for_status()
             return response.json().get("data", [])
         except requests.RequestException as exc:

--- a/tests/test_noco_api.py
+++ b/tests/test_noco_api.py
@@ -26,6 +26,10 @@ def test_list_fields():
     with mock.patch.object(requests, "get", return_value=fake_resp) as get:
         result = api.list_fields("posts")
 
-    get.assert_called_once()
+    get.assert_called_once_with(
+        "http://api/collections/posts/fields:list",
+        headers=api._headers(),
+        params={"paginate": "false"},
+    )
     assert result == ["f1", "f2"]
 


### PR DESCRIPTION
## Summary
- pass `paginate=false` when listing fields in `noco_api` wrapper
- verify GET arguments in `test_noco_api.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f611782d8832dba12e0e06c09bfed