### PR TITLE
Add data-filled CSV template support

### DIFF
--- a/agents/csv_generator.py
+++ b/agents/csv_generator.py
@@ -30,8 +30,14 @@ def generate_csv(csv_file_path: str, field_names: List[str], records: Iterable[D
             writer.writerow(row)
 
 
-def generate_template(csv_file_path: str, collection_name: str, api: NocoAPI) -> None:
-    """Generate an empty CSV template for a collection.
+def generate_template(
+    csv_file_path: str,
+    collection_name: str,
+    api: NocoAPI,
+    *,
+    include_data: bool = False,
+) -> None:
+    """Generate a CSV template for a collection.
 
     Parameters
     ----------
@@ -41,8 +47,13 @@ def generate_template(csv_file_path: str, collection_name: str, api: NocoAPI) ->
         Name of the collection to inspect for fields.
     api: NocoAPI
         Authenticated API client used to fetch field information.
+    include_data: bool, optional
+        If ``True`` include existing records in the generated CSV.
     """
     fields = api.list_fields(collection_name)
     field_names = [field["name"] for field in fields]
-    generate_csv(csv_file_path, field_names, [])
+    records: Iterable[Dict[str, Any]] = []
+    if include_data:
+        records = api.list_records(collection_name)
+    generate_csv(csv_file_path, field_names, records)
 

--- a/agents/noco_api.py
+++ b/agents/noco_api.py
@@ -39,6 +39,20 @@ class NocoAPI:
         except requests.RequestException as exc:
             raise RuntimeError(f"Failed to list fields: {exc}") from exc
 
+    def list_records(self, collection_name: str) -> List[Dict[str, Any]]:
+        """Return all records for a given collection."""
+        url = f"{self.api_url}/{collection_name}:list"
+        try:
+            response = requests.get(
+                url,
+                headers=self._headers(),
+                params={"paginate": "false"},
+            )
+            response.raise_for_status()
+            return response.json().get("data", [])
+        except requests.RequestException as exc:
+            raise RuntimeError(f"Failed to list records: {exc}") from exc
+
     def create_record(self, collection_name: str, data: Dict[str, Any]) -> Dict[str, Any]:
         """Create a record in the specified collection.
 

--- a/main.py
+++ b/main.py
@@ -18,6 +18,11 @@ def main() -> None:
     tmpl.add_argument("collection", help="Collection name")
     tmpl.add_argument("output_csv", help="Path to write the template CSV")
     tmpl.add_argument("--authenticator", default="local", help="Authenticator name")
+    tmpl.add_argument(
+        "--include-data",
+        action="store_true",
+        help="Include existing records in the template",
+    )
 
     up = sub.add_parser("upload", help="Upload CSV data")
     up.add_argument("api_url", help="Base API URL")
@@ -33,7 +38,12 @@ def main() -> None:
     api = NocoAPI(args.api_url, token)
 
     if args.command == "template":
-        generate_template(args.output_csv, args.collection, api)
+        generate_template(
+            args.output_csv,
+            args.collection,
+            api,
+            include_data=args.include_data,
+        )
     elif args.command == "upload":
         upload_csv_data(args.csv_file, args.collection, api)
 

--- a/tests/test_csv_generator.py
+++ b/tests/test_csv_generator.py
@@ -23,11 +23,26 @@ def test_generate_template(tmp_path):
     api = mock.Mock()
     api.list_fields.return_value = [{"name": "id"}, {"name": "name"}]
 
-    csv_generator.generate_template(str(csv_file), "posts", api)
+    csv_generator.generate_template(str(csv_file), "posts", api, include_data=False)
 
     with open(csv_file, newline="", encoding="utf-8") as f:
         reader = csv.reader(f)
         headers = next(reader)
 
+
     assert headers == ["id", "name"]
+
+
+def test_generate_template_with_data(tmp_path):
+    csv_file = tmp_path / "template.csv"
+    api = mock.Mock()
+    api.list_fields.return_value = [{"name": "id"}, {"name": "name"}]
+    api.list_records.return_value = [{"id": 1, "name": "A"}]
+
+    csv_generator.generate_template(str(csv_file), "posts", api, include_data=True)
+
+    with open(csv_file, newline="", encoding="utf-8") as f:
+        rows = list(csv.DictReader(f))
+
+    assert rows == [{"id": "1", "name": "A"}]
 

--- a/tests/test_noco_api.py
+++ b/tests/test_noco_api.py
@@ -33,3 +33,20 @@ def test_list_fields():
     )
     assert result == ["f1", "f2"]
 
+
+def test_list_records():
+    api = NocoAPI("http://api", "token")
+    fake_resp = mock.Mock()
+    fake_resp.json.return_value = {"data": [{"name": "A"}]}
+    fake_resp.raise_for_status.return_value = None
+
+    with mock.patch.object(requests, "get", return_value=fake_resp) as get:
+        result = api.list_records("posts")
+
+    get.assert_called_once_with(
+        "http://api/posts:list",
+        headers=api._headers(),
+        params={"paginate": "false"},
+    )
+    assert result == [{"name": "A"}]
+


### PR DESCRIPTION
## Summary
- expose `list_records` in `NocoAPI`
- allow exporting CSV template with existing records
- support `--include-data` CLI flag
- test CSV generator with `include_data` option
- test record listing in `NocoAPI`

## Testing
- `pip install requests`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f6712da80832d8ff71ac93c8f26be