### PR TITLE
Fix CSV export when records have extra fields

### DIFF
--- a/agents/csv_generator.py
+++ b/agents/csv_generator.py
@@ -21,10 +21,12 @@ def generate_csv(csv_file_path: str, field_names: List[str], records: Iterable[D
         Image URL to insert into each record if `image_field` is given.
     """
     with open(csv_file_path, "w", newline="", encoding="utf-8") as csvfile:
-        writer = csv.DictWriter(csvfile, fieldnames=field_names)
+        writer = csv.DictWriter(
+            csvfile, fieldnames=field_names, extrasaction="ignore"
+        )
         writer.writeheader()
         for record in records:
-            row = dict(record)
+            row = {key: record.get(key) for key in field_names}
             if image_field and image_url:
                 row[image_field] = image_url
             writer.writerow(row)

--- a/tests/test_csv_generator.py
+++ b/tests/test_csv_generator.py
@@ -18,6 +18,19 @@ def test_generate_csv(tmp_path):
     assert rows == [{"id": "1", "name": "A", "image": "http://img"}]
 
 
+def test_generate_csv_ignore_extra_fields(tmp_path):
+    csv_file = tmp_path / "extra.csv"
+    field_names = ["id", "name"]
+    records = [{"id": 1, "name": "A", "unused": "x"}]
+
+    csv_generator.generate_csv(str(csv_file), field_names, records)
+
+    with open(csv_file, newline="", encoding="utf-8") as f:
+        rows = list(csv.DictReader(f))
+
+    assert rows == [{"id": "1", "name": "A"}]
+
+
 def test_generate_template(tmp_path):
     csv_file = tmp_path / "template.csv"
     api = mock.Mock()
@@ -37,7 +50,7 @@ def test_generate_template_with_data(tmp_path):
     csv_file = tmp_path / "template.csv"
     api = mock.Mock()
     api.list_fields.return_value = [{"name": "id"}, {"name": "name"}]
-    api.list_records.return_value = [{"id": 1, "name": "A"}]
+    api.list_records.return_value = [{"id": 1, "name": "A", "extra": "x"}]
 
     csv_generator.generate_template(str(csv_file), "posts", api, include_data=True)
 


### PR DESCRIPTION
## Summary
- ignore extra fields when generating CSV templates
- test for ignoring additional fields

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880442eb690832da48f88ad5227013b