### PR TITLE
Improve template CSV download

### DIFF
--- a/agents/csv_generator.py
+++ b/agents/csv_generator.py
@@ -53,7 +53,35 @@ def generate_template(
         If ``True`` include existing records in the generated CSV.
     """
     fields = api.list_fields(collection_name)
-    field_names = [field["name"] for field in fields]
+
+    relation_interfaces = {
+        "o2o",
+        "oho",
+        "obo",
+        "o2m",
+        "m2o",
+        "m2m",
+        "linkTo",
+        "mbm",
+        "subTable",
+    }
+    relation_types = {
+        "belongsTo",
+        "hasOne",
+        "hasMany",
+        "belongsToMany",
+        "linkTo",
+    }
+
+    field_names = [
+        f["name"]
+        for f in fields
+        if f.get("interface") not in relation_interfaces
+        and f.get("type") not in relation_types
+        and f.get("interface") != "formula"
+        and f.get("type") != "formula"
+    ]
+
     records: Iterable[Dict[str, Any]] = []
     if include_data:
         records = api.list_records(collection_name)

--- a/tests/test_csv_generator.py
+++ b/tests/test_csv_generator.py
@@ -34,7 +34,12 @@ def test_generate_csv_ignore_extra_fields(tmp_path):
 def test_generate_template(tmp_path):
     csv_file = tmp_path / "template.csv"
     api = mock.Mock()
-    api.list_fields.return_value = [{"name": "id"}, {"name": "name"}]
+    api.list_fields.return_value = [
+        {"name": "id"},
+        {"name": "name"},
+        {"name": "calc", "interface": "formula"},
+        {"name": "author", "type": "belongsTo"},
+    ]
 
     csv_generator.generate_template(str(csv_file), "posts", api, include_data=False)
 
@@ -49,8 +54,15 @@ def test_generate_template(tmp_path):
 def test_generate_template_with_data(tmp_path):
     csv_file = tmp_path / "template.csv"
     api = mock.Mock()
-    api.list_fields.return_value = [{"name": "id"}, {"name": "name"}]
-    api.list_records.return_value = [{"id": 1, "name": "A", "extra": "x"}]
+    api.list_fields.return_value = [
+        {"name": "id"},
+        {"name": "name"},
+        {"name": "calc", "interface": "formula"},
+        {"name": "author", "type": "hasOne"},
+    ]
+    api.list_records.return_value = [
+        {"id": 1, "name": "A", "calc": 2, "author": 5}
+    ]
 
     csv_generator.generate_template(str(csv_file), "posts", api, include_data=True)
 


### PR DESCRIPTION
## Summary
- filter formula & relationship fields when generating template CSVs
- test new filtering behaviour

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68819faffce4832d8baf8e01daf40149