### PR TITLE
Add CSV row sanitization

### DIFF
--- a/agents/data_uploader.py
+++ b/agents/data_uploader.py
@@ -1,7 +1,36 @@
+import ast
 import csv
 from typing import Any, Dict
 
 from .noco_api import NocoAPI
+
+
+def sanitize_row(row: Dict[str, Any], *, parse_lists: bool = True) -> Dict[str, Any]:
+    """Return a sanitized copy of a CSV row.
+
+    Empty strings are converted to ``None``. When ``parse_lists`` is ``True``,
+    values that look like Python list literals are converted to actual lists
+    using :func:`ast.literal_eval`.
+    """
+
+    sanitized: Dict[str, Any] = {}
+    for key, value in row.items():
+        if value == "":
+            sanitized[key] = None
+            continue
+
+        if parse_lists and isinstance(value, str):
+            text = value.strip()
+            if text.startswith("[") and text.endswith("]"):
+                try:
+                    sanitized[key] = ast.literal_eval(text)
+                    continue
+                except (ValueError, SyntaxError):  # pragma: no cover - safety
+                    pass
+
+        sanitized[key] = value
+
+    return sanitized
 
 
 def upload_csv_data(csv_file_path: str, collection_name: str, api: NocoAPI) -> None:
@@ -19,5 +48,5 @@ def upload_csv_data(csv_file_path: str, collection_name: str, api: NocoAPI) -> N
     with open(csv_file_path, newline="", encoding="utf-8") as csvfile:
         reader = csv.DictReader(csvfile)
         for row in reader:
-            api.create_record(collection_name, row)
+            api.create_record(collection_name, sanitize_row(row))
 

--- a/tests/test_data_uploader.py
+++ b/tests/test_data_uploader.py
@@ -21,3 +21,31 @@ def test_upload_csv_data(tmp_path):
     create_record.assert_any_call("posts", {"name": "A"})
     create_record.assert_any_call("posts", {"name": "B"})
 
+
+def test_empty_strings_become_none(tmp_path):
+    csv_file = tmp_path / "data.csv"
+    with open(csv_file, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=["name", "desc"])
+        writer.writeheader()
+        writer.writerow({"name": "A", "desc": ""})
+
+    api = NocoAPI("http://api", "token")
+    with mock.patch.object(api, "create_record") as create_record:
+        upload_csv_data(str(csv_file), "posts", api)
+
+    create_record.assert_called_once_with("posts", {"name": "A", "desc": None})
+
+
+def test_list_strings_are_parsed(tmp_path):
+    csv_file = tmp_path / "data.csv"
+    with open(csv_file, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=["tags"])
+        writer.writeheader()
+        writer.writerow({"tags": "['服装']"})
+
+    api = NocoAPI("http://api", "token")
+    with mock.patch.object(api, "create_record") as create_record:
+        upload_csv_data(str(csv_file), "posts", api)
+
+    create_record.assert_called_once_with("posts", {"tags": ["服装"]})
+


### PR DESCRIPTION
## Summary
- sanitize CSV rows before sending to API
- convert empty string cells to `None` and parse list strings
- call new helper when uploading CSV data
- test sanitization behavior

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881a85f0088832d946f6f18cc88ec81