### PR TITLE
Add encoding option for CSV upload

### DIFF
--- a/agents/data_uploader.py
+++ b/agents/data_uploader.py
@@ -33,7 +33,13 @@ def sanitize_row(row: Dict[str, Any], *, parse_lists: bool = True) -> Dict[str, 
     return sanitized
 
 
-def upload_csv_data(csv_file_path: str, collection_name: str, api: NocoAPI) -> None:
+def upload_csv_data(
+    csv_file_path: str,
+    collection_name: str,
+    api: NocoAPI,
+    *,
+    encoding: str = "utf-8",
+) -> None:
     """Upload records from a CSV file to a NocoBase collection.
 
     Parameters
@@ -44,8 +50,10 @@ def upload_csv_data(csv_file_path: str, collection_name: str, api: NocoAPI) -> N
         Name of the collection to upload records to.
     api: NocoAPI
         Authenticated API client.
+    encoding: str, optional
+        Character encoding used when reading ``csv_file_path``.
     """
-    with open(csv_file_path, newline="", encoding="utf-8") as csvfile:
+    with open(csv_file_path, newline="", encoding=encoding) as csvfile:
         reader = csv.DictReader(csvfile)
         for row in reader:
             api.create_record(collection_name, sanitize_row(row))

--- a/main.py
+++ b/main.py
@@ -31,6 +31,11 @@ def main() -> None:
     up.add_argument("collection", help="Collection name")
     up.add_argument("csv_file", help="CSV file with records")
     up.add_argument("--authenticator", default="local", help="Authenticator name")
+    up.add_argument(
+        "--encoding",
+        default="utf-8",
+        help="Encoding of the CSV file (default: utf-8)",
+    )
 
     args = parser.parse_args()
 
@@ -45,7 +50,9 @@ def main() -> None:
             include_data=args.include_data,
         )
     elif args.command == "upload":
-        upload_csv_data(args.csv_file, args.collection, api)
+        upload_csv_data(
+            args.csv_file, args.collection, api, encoding=args.encoding
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_data_uploader.py
+++ b/tests/test_data_uploader.py
@@ -49,3 +49,17 @@ def test_list_strings_are_parsed(tmp_path):
 
     create_record.assert_called_once_with("posts", {"tags": ["服装"]})
 
+
+def test_custom_encoding(tmp_path):
+    csv_file = tmp_path / "data.csv"
+    with open(csv_file, "w", newline="", encoding="latin-1") as f:
+        writer = csv.DictWriter(f, fieldnames=["name"])
+        writer.writeheader()
+        writer.writerow({"name": "Æ"})
+
+    api = NocoAPI("http://api", "token")
+    with mock.patch.object(api, "create_record") as create_record:
+        upload_csv_data(str(csv_file), "posts", api, encoding="latin-1")
+
+    create_record.assert_called_once_with("posts", {"name": "Æ"})
+


### PR DESCRIPTION
## Summary
- allow specifying encoding when uploading CSV data
- pass encoding argument to upload_csv_data
- read CSV files using the provided encoding
- test uploading with a custom encoding

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881ab489e50832daed2332a7979c0ad