### PR TITLE
Add upsert support to CSV uploader

### DIFF
--- a/agents/noco_api.py
+++ b/agents/noco_api.py
@@ -76,3 +76,49 @@ class NocoAPI:
         except requests.RequestException as exc:
             raise RuntimeError(f"Failed to create record: {exc}") from exc
 
+    def update_record(
+        self, collection_name: str, record_id: str, data: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        """Update a record in the specified collection.
+
+        Parameters
+        ----------
+        collection_name: str
+            Name of the collection to update.
+        record_id: str
+            Identifier of the record to update.
+        data: Dict[str, Any]
+            Updated record values.
+
+        Returns
+        -------
+        Dict[str, Any]
+            Response data from the API.
+        """
+        url = f"{self.api_url}/{collection_name}:update"
+        payload = {"filter": {"id": record_id}, "values": data}
+        try:
+            response = requests.post(url, json=payload, headers=self._headers())
+            response.raise_for_status()
+            return response.json().get("data", {})
+        except requests.RequestException as exc:
+            raise RuntimeError(f"Failed to update record: {exc}") from exc
+
+    def upsert_record(
+        self,
+        collection_name: str,
+        record_id: str | None,
+        data: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        """Update the record if ``record_id`` is provided, otherwise create it.
+
+        When ``record_id`` is specified, the method attempts an update first and
+        falls back to creation if the update fails.
+        """
+        if record_id:
+            try:
+                return self.update_record(collection_name, record_id, data)
+            except RuntimeError:
+                pass
+        return self.create_record(collection_name, data)
+

--- a/main.py
+++ b/main.py
@@ -36,6 +36,11 @@ def main() -> None:
         default="utf-8",
         help="Encoding of the CSV file (default: utf-8)",
     )
+    up.add_argument(
+        "--use-upsert",
+        action="store_true",
+        help="Use upsert when an id column is present",
+    )
 
     args = parser.parse_args()
 
@@ -51,7 +56,11 @@ def main() -> None:
         )
     elif args.command == "upload":
         upload_csv_data(
-            args.csv_file, args.collection, api, encoding=args.encoding
+            args.csv_file,
+            args.collection,
+            api,
+            encoding=args.encoding,
+            use_upsert=args.use_upsert,
         )
 
 

--- a/tests/test_data_uploader.py
+++ b/tests/test_data_uploader.py
@@ -63,3 +63,17 @@ def test_custom_encoding(tmp_path):
 
     create_record.assert_called_once_with("posts", {"name": "Æ"})
 
+
+def test_upsert_when_id_present(tmp_path):
+    csv_file = tmp_path / "data.csv"
+    with open(csv_file, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=["id", "name"])
+        writer.writeheader()
+        writer.writerow({"id": "1", "name": "A"})
+
+    api = NocoAPI("http://api", "token")
+    with mock.patch.object(api, "upsert_record") as upsert:
+        upload_csv_data(str(csv_file), "posts", api, use_upsert=True)
+
+    upsert.assert_called_once_with("posts", "1", {"name": "A"})
+

--- a/tests/test_noco_api.py
+++ b/tests/test_noco_api.py
@@ -50,3 +50,50 @@ def test_list_records():
     )
     assert result == [{"name": "A"}]
 
+
+def test_update_record():
+    api = NocoAPI("http://api", "token")
+    fake_resp = mock.Mock()
+    fake_resp.json.return_value = {"data": {"id": 1}}
+    fake_resp.raise_for_status.return_value = None
+
+    with mock.patch.object(requests, "post", return_value=fake_resp) as post:
+        result = api.update_record("posts", "1", {"name": "B"})
+
+    post.assert_called_once_with(
+        "http://api/posts:update",
+        json={"filter": {"id": "1"}, "values": {"name": "B"}},
+        headers=api._headers(),
+    )
+    assert result == {"id": 1}
+
+
+def test_upsert_record_update_success():
+    api = NocoAPI("http://api", "token")
+    with mock.patch.object(api, "update_record", return_value={"ok": True}) as upd, \
+        mock.patch.object(api, "create_record") as create:
+        result = api.upsert_record("posts", "1", {"name": "B"})
+
+    upd.assert_called_once_with("posts", "1", {"name": "B"})
+    create.assert_not_called()
+    assert result == {"ok": True}
+
+
+def test_upsert_record_fallback_to_create():
+    api = NocoAPI("http://api", "token")
+    with mock.patch.object(api, "update_record", side_effect=RuntimeError):
+        with mock.patch.object(api, "create_record", return_value={"id": 2}) as cr:
+            result = api.upsert_record("posts", "2", {"name": "C"})
+
+    cr.assert_called_once_with("posts", {"name": "C"})
+    assert result == {"id": 2}
+
+
+def test_upsert_record_create_when_no_id():
+    api = NocoAPI("http://api", "token")
+    with mock.patch.object(api, "create_record", return_value={"id": 3}) as cr:
+        result = api.upsert_record("posts", None, {"name": "D"})
+
+    cr.assert_called_once_with("posts", {"name": "D"})
+    assert result == {"id": 3}
+


### PR DESCRIPTION
## Summary
- support update and upsert operations in `NocoAPI`
- optionally use upsert when uploading CSV data
- expose `--use-upsert` CLI flag
- test update and upsert logic

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881ad0a5fe4832da4d7d674edc173ed