### PR TITLE
Normalize CSV header casing

### DIFF
--- a/agents/data_uploader.py
+++ b/agents/data_uploader.py
@@ -60,9 +60,14 @@ def upload_csv_data(
     """
     with open(csv_file_path, newline="", encoding=encoding) as csvfile:
         reader = csv.DictReader(csvfile)
+        reader.fieldnames = [name.lower() for name in reader.fieldnames]
         for row in reader:
             sanitized = sanitize_row(row)
-            if use_upsert and "id" in sanitized and sanitized["id"] is not None:
+            if (
+                use_upsert
+                and any(k.lower() == "id" for k in row)
+                and sanitized.get("id") is not None
+            ):
                 record_id = sanitized.pop("id")
                 api.upsert_record(collection_name, record_id, sanitized)
             else:

--- a/tests/test_data_uploader.py
+++ b/tests/test_data_uploader.py
@@ -77,3 +77,17 @@ def test_upsert_when_id_present(tmp_path):
 
     upsert.assert_called_once_with("posts", "1", {"name": "A"})
 
+
+def test_upsert_when_id_uppercase(tmp_path):
+    csv_file = tmp_path / "data.csv"
+    with open(csv_file, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=["ID", "name"])
+        writer.writeheader()
+        writer.writerow({"ID": "1", "name": "A"})
+
+    api = NocoAPI("http://api", "token")
+    with mock.patch.object(api, "upsert_record") as upsert:
+        upload_csv_data(str(csv_file), "posts", api, use_upsert=True)
+
+    upsert.assert_called_once_with("posts", "1", {"name": "A"})
+


### PR DESCRIPTION
## Summary
- lowercase headers when uploading CSV data
- detect `id` column case-insensitively
- test uppercase `ID` header handling

## Testing
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881dc56e048832dab10cf8650ea3cf1