### PR TITLE
Fix whitespace handling in CSV uploads

### DIFF
--- a/agents/README.md
+++ b/agents/README.md
@@ -44,7 +44,7 @@ generate_csv("output.csv", field_names, records,
 
 `upload_csv_data` sanitizes each row before sending it to the API:
 
-- empty strings become `None`
+- empty or whitespace-only strings become `None`
 - strings that look like Python list literals are parsed into lists
 
 The `upload` command accepts an `--encoding` option to specify the file's character set:

--- a/agents/data_uploader.py
+++ b/agents/data_uploader.py
@@ -15,18 +15,21 @@ def sanitize_row(row: Dict[str, Any], *, parse_lists: bool = True) -> Dict[str, 
 
     sanitized: Dict[str, Any] = {}
     for key, value in row.items():
-        if value == "":
-            sanitized[key] = None
-            continue
-
-        if parse_lists and isinstance(value, str):
+        if isinstance(value, str):
             text = value.strip()
-            if text.startswith("[") and text.endswith("]"):
+            if text == "":
+                sanitized[key] = None
+                continue
+
+            if parse_lists and text.startswith("[") and text.endswith("]"):
                 try:
                     sanitized[key] = ast.literal_eval(text)
                     continue
                 except (ValueError, SyntaxError):  # pragma: no cover - safety
                     pass
+
+            sanitized[key] = text
+            continue
 
         sanitized[key] = value
 

--- a/tests/test_data_uploader.py
+++ b/tests/test_data_uploader.py
@@ -36,6 +36,20 @@ def test_empty_strings_become_none(tmp_path):
     create_record.assert_called_once_with("posts", {"name": "A", "desc": None})
 
 
+def test_whitespace_is_treated_as_empty(tmp_path):
+    csv_file = tmp_path / "data.csv"
+    with open(csv_file, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=["name", "price"])
+        writer.writeheader()
+        writer.writerow({"name": "A", "price": "   "})
+
+    api = NocoAPI("http://api", "token")
+    with mock.patch.object(api, "create_record") as create_record:
+        upload_csv_data(str(csv_file), "posts", api)
+
+    create_record.assert_called_once_with("posts", {"name": "A", "price": None})
+
+
 def test_list_strings_are_parsed(tmp_path):
     csv_file = tmp_path / "data.csv"
     with open(csv_file, "w", newline="", encoding="utf-8") as f:


### PR DESCRIPTION
## Summary
- sanitize CSV values by trimming whitespace
- treat whitespace-only strings as empty
- document improved sanitization in README
- test whitespace handling in `upload_csv_data`

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881df260ba0832da8b4cfea00ef8782