### PR TITLE
Embed config defaults and update auth usage

### DIFF
--- a/agents/auth.py
+++ b/agents/auth.py
@@ -1,7 +1,14 @@
 import requests
 
+from . import config
 
-def authenticate_user(api_url: str, username: str, password: str, authenticator: str = "local") -> str:
+
+def authenticate_user(
+    api_url: str | None = None,
+    username: str | None = None,
+    password: str | None = None,
+    authenticator: str | None = None,
+) -> str:
     """Authenticate with the NocoBase API and return a bearer token.
 
     Parameters
@@ -27,6 +34,15 @@ def authenticate_user(api_url: str, username: str, password: str, authenticator:
     KeyError
         If the token is missing in the response.
     """
+    if api_url is None:
+        api_url = config.API_URL
+    if username is None:
+        username = config.USERNAME
+    if password is None:
+        password = config.PASSWORD
+    if authenticator is None:
+        authenticator = config.AUTHENTICATOR
+
     url = f"{api_url}/auth:signIn"
     headers = {
         "Content-Type": "application/json",

--- a/agents/config.py
+++ b/agents/config.py
@@ -1,0 +1,7 @@
+# Default configuration for NocoBase helpers.
+
+API_URL = "http://erp.vdnet.top:13000/api"
+USERNAME = "admin@nocobase.com"
+PASSWORD = "qaz123456@ products"
+AUTHENTICATOR = "basic"
+

--- a/main.py
+++ b/main.py
@@ -1,5 +1,6 @@
 import argparse
 
+from agents import config
 from agents.auth import authenticate_user
 from agents.noco_api import NocoAPI
 from agents.data_uploader import upload_csv_data
@@ -12,12 +13,8 @@ def main() -> None:
     sub = parser.add_subparsers(dest="command", required=True)
 
     tmpl = sub.add_parser("template", help="Download CSV template")
-    tmpl.add_argument("api_url", help="Base API URL")
-    tmpl.add_argument("username", help="User email for authentication")
-    tmpl.add_argument("password", help="User password")
     tmpl.add_argument("collection", help="Collection name")
     tmpl.add_argument("output_csv", help="Path to write the template CSV")
-    tmpl.add_argument("--authenticator", default="local", help="Authenticator name")
     tmpl.add_argument(
         "--include-data",
         action="store_true",
@@ -25,12 +22,8 @@ def main() -> None:
     )
 
     up = sub.add_parser("upload", help="Upload CSV data")
-    up.add_argument("api_url", help="Base API URL")
-    up.add_argument("username", help="User email for authentication")
-    up.add_argument("password", help="User password")
     up.add_argument("collection", help="Collection name")
     up.add_argument("csv_file", help="CSV file with records")
-    up.add_argument("--authenticator", default="local", help="Authenticator name")
     up.add_argument(
         "--encoding",
         default="utf-8",
@@ -44,8 +37,8 @@ def main() -> None:
 
     args = parser.parse_args()
 
-    token = authenticate_user(args.api_url, args.username, args.password, args.authenticator)
-    api = NocoAPI(args.api_url, token)
+    token = authenticate_user()
+    api = NocoAPI(config.API_URL, token)
 
     if args.command == "template":
         generate_template(

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,7 +1,7 @@
 from unittest import mock
 import requests
 
-from agents import auth
+from agents import auth, config
 
 
 def test_authenticate_user_success():
@@ -9,8 +9,14 @@ def test_authenticate_user_success():
     fake_response.json.return_value = {"data": {"token": "abc"}}
     fake_response.raise_for_status.return_value = None
 
-    with mock.patch.object(requests, "post", return_value=fake_response) as post:
-        token = auth.authenticate_user("http://api", "user", "pass")
+    with (
+        mock.patch.object(requests, "post", return_value=fake_response) as post,
+        mock.patch.object(config, "API_URL", "http://api"),
+        mock.patch.object(config, "USERNAME", "user"),
+        mock.patch.object(config, "PASSWORD", "pass"),
+        mock.patch.object(config, "AUTHENTICATOR", "basic"),
+    ):
+        token = auth.authenticate_user()
 
     post.assert_called_once()
     assert token == "abc"


### PR DESCRIPTION
## Summary
- add `agents/config.py` to store default API credentials
- fallback to config values when calling `authenticate_user`
- simplify CLI to read credentials from config
- update authentication test to use the config defaults

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882f0215160832da83d2a11a08a0b49