### PR TITLE
Add folder image upload docs

### DIFF
--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -103,3 +103,26 @@ python main.py template posts posts.csv
 # 编辑 posts.csv 后
 python main.py upload posts posts.csv --use-upsert
 ```
+
+### 批量上传图片
+
+若需要一次性上传文件夹中的所有图片，可使用 `agents.image_uploader`
+提供的 `upload_images_in_folder` 函数，并可配合 `download_files_csv`
+导出文件管理器数据：
+
+```python
+from agents import config
+from agents.auth import authenticate_user
+from agents.noco_api import NocoAPI
+from agents.image_uploader import upload_images_in_folder, download_files_csv
+
+token = authenticate_user()
+api = NocoAPI(config.API_URL, token)
+
+# 上传文件夹中的所有图片到 attachments 集合
+urls = upload_images_in_folder(config.API_URL, token, "attachments", "./images")
+
+# 可选：将文件管理器中的数据保存为 CSV
+download_files_csv(api, "attachments", "files.csv")
+print(urls)
+```

--- a/agents/README.md
+++ b/agents/README.md
@@ -40,6 +40,23 @@ generate_csv("output.csv", field_names, records,
              image_field="image", image_url=image_url)
 ```
 
+## Uploading Images From a Folder
+
+`upload_images_in_folder` uploads every file in a directory and returns
+their URLs. You may then export the file manager data to CSV with
+`download_files_csv`:
+
+```python
+from agents.image_uploader import (
+    upload_images_in_folder,
+    download_files_csv,
+)
+
+urls = upload_images_in_folder(api_url, token, "attachments", "./images")
+download_files_csv(api, "attachments", "files.csv")
+print(urls)
+```
+
 ## Uploading CSV Data
 
 `upload_csv_data` sanitizes each row before sending it to the API:


### PR DESCRIPTION
## Summary
- document `upload_images_in_folder` usage in agents README
- add Chinese instructions for batch uploading images in README.zh-CN

## Testing
- `pip install requests -q`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688303af76cc832dbff0a757d77802af