### PR TITLE
Adjust table ops, image preview and URL style

### DIFF
--- a/packages/core/client/src/schema-component/antd/input/ReadPretty.tsx
+++ b/packages/core/client/src/schema-component/antd/input/ReadPretty.tsx
@@ -10,6 +10,7 @@
 import { css, cx } from '@emotion/css';
 import { usePrefixCls } from '@formily/antd-v5/esm/__builtins__';
 import { useFieldSchema } from '@formily/react';
+import { LinkOutlined } from '@ant-design/icons';
 import { Image } from 'antd';
 import cls from 'classnames';
 import _ from 'lodash';
@@ -214,8 +215,13 @@ ReadPretty.URL = (props: URLReadPrettyProps) => {
   // eslint-disable-next-line react-hooks/rules-of-hooks
   const prefixCls = usePrefixCls('description-url', props);
   const content = props.value && (
-    <a style={props.ellipsis ? ellipsisStyle : undefined} target="_blank" rel="noopener noreferrer" href={props.value}>
-      {props.value}
+    <a
+      style={props.ellipsis ? ellipsisStyle : undefined}
+      target="_blank"
+      rel="noopener noreferrer"
+      href={props.value}
+    >
+      <LinkOutlined />
     </a>
   );
   return (

--- a/packages/plugins/@nocobase/plugin-field-attachment-url/src/client/interfaces/attachment-url.tsx
+++ b/packages/plugins/@nocobase/plugin-field-attachment-url/src/client/interfaces/attachment-url.tsx
@@ -75,7 +75,7 @@ export class AttachmentURLFieldInterface extends CollectionFieldInterface {
     schema['x-component-props']['mode'] = 'AttachmentUrl';
     if (['Table', 'Kanban'].includes(block)) {
       schema['x-component-props']['ellipsis'] = true;
-      schema['x-component-props']['size'] = 'small';
+      schema['x-component-props']['size'] = 'large';
     }
   }
   filterable = {


### PR DESCRIPTION
## Summary
- show bigger previews for AttachmentUrl fields in tables
- display URL fields as a link icon only

## Testing
- `yarn lint` *(fails: package missing in lockfile)*
- `yarn test` *(fails: package missing in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6889e3e42258832d860ac79d3c825fb4