### PR TITLE
Enhance table action cell and attachment preview

### DIFF
--- a/packages/core/client/src/schema-component/antd/table-v2/Table.tsx
+++ b/packages/core/client/src/schema-component/antd/table-v2/Table.tsx
@@ -507,6 +507,14 @@ const cellClass = css`
   }
 `;
 
+const actionCellClass = css`
+  white-space: normal;
+  .ant-space {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+`;
+
 const rowSelectCheckboxWrapperClass = css`
   position: relative;
   display: flex;
@@ -636,8 +644,13 @@ const InternalBodyCellComponent = React.memo<BodyCellComponentProps>((props) => 
     (!!schema?.properties && Object.values(schema.properties).some((item) => item['x-read-pretty'] === true)) ||
     schema?.['x-action-column'] === 'actions';
   const mergedStyle = useMemo(
-    () => ({ overflow: 'hidden', ...props.style, ...dynamicStyle }),
-    [props.style, dynamicStyle],
+    () => ({
+      overflow: 'hidden',
+      ...(schema?.['x-action-column'] === 'actions' ? { whiteSpace: 'normal' } : {}),
+      ...props.style,
+      ...dynamicStyle,
+    }),
+    [props.style, dynamicStyle, schema?.['x-action-column']],
   );
   return (
     <FlagProvider isInTableCell>
@@ -645,7 +658,15 @@ const InternalBodyCellComponent = React.memo<BodyCellComponentProps>((props) => 
       {!_.isEmpty(styleRules) && (
         <GetStyleRules record={record} schema={schema} onStyleChange={isReadPrettyMode ? setDynamicStyle : _.noop} />
       )}
-      <td {...others} className={classNames(props.className, cellClass)} style={mergedStyle}>
+      <td
+        {...others}
+        className={classNames(
+          props.className,
+          cellClass,
+          schema?.['x-action-column'] === 'actions' && actionCellClass,
+        )}
+        style={mergedStyle}
+      >
         {props.children}
       </td>
     </FlagProvider>

--- a/packages/core/client/src/schema-component/antd/upload/Upload.tsx
+++ b/packages/core/client/src/schema-component/antd/upload/Upload.tsx
@@ -199,6 +199,8 @@ function ReadPretty({ value, onChange, disabled, multiple, size, ...others }: Up
   useUploadStyleVal(prefixCls);
   const { isInTableCell } = useFlag();
 
+  const actualSize = size || (isInTableCell ? 48 : undefined);
+
   const resetStyle = useMemo(() => (isInTableCell ? { display: 'inline-block' } : {}), [isInTableCell]);
 
   return wrapSSR(
@@ -207,12 +209,12 @@ function ReadPretty({ value, onChange, disabled, multiple, size, ...others }: Up
         `${prefixCls}-wrapper`,
         `${prefixCls}-picture-card-wrapper`,
         `nb-upload`,
-        size ? `nb-upload-${size}` : null,
+        actualSize ? `nb-upload-${actualSize}` : null,
         hashId,
         css`
           .ant-upload-list-picture-card-container {
-            width: ${size}px !important;
-            height: ${size}px !important;
+            width: ${actualSize}px !important;
+            height: ${actualSize}px !important;
           }
         `,
       )}


### PR DESCRIPTION
## Summary
- allow wrapping buttons in table action column
- enlarge default attachment preview in table cells

## Testing
- `yarn lint` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_688b3a6bb380832da606cd2ccbd10ad2