### PR TITLE
Improve table and preview styles

### DIFF
--- a/packages/core/client/src/modules/fields/component/Input.Preview/settings.ts
+++ b/packages/core/client/src/modules/fields/component/Input.Preview/settings.ts
@@ -71,7 +71,7 @@ const size = createSettingsItem({
   name: 'size',
   title: 'Size',
   options: getSizeOptions,
-  defaultValue: 'small',
+  defaultValue: 'middle',
 });
 
 const objectFit = createSettingsItem({

--- a/packages/core/client/src/schema-component/antd/input/ReadPretty.tsx
+++ b/packages/core/client/src/schema-component/antd/input/ReadPretty.tsx
@@ -244,7 +244,7 @@ const sizes = {
 
 ReadPretty.Preview = function Preview(props: any) {
   const fieldSchema = useFieldSchema();
-  const size = fieldSchema['x-component-props']?.['size'] || 'small';
+  const size = fieldSchema['x-component-props']?.['size'] || 'middle';
   const objectFit = fieldSchema['x-component-props']?.['objectFit'] || 'cover';
 
   if (!props.value) {

--- a/packages/core/client/src/schema-component/antd/table-v2/Table.tsx
+++ b/packages/core/client/src/schema-component/antd/table-v2/Table.tsx
@@ -508,6 +508,7 @@ const cellClass = css`
 const actionCellClass = css`
   white-space: normal;
   .ant-space {
+    display: flex;
     flex-direction: column;
     align-items: flex-start;
   }


### PR DESCRIPTION
## Summary
- allow vertical layout for action column cells
- default Input.Preview size is larger for better image preview
- enlarge default preview size for read-only images

## Testing
- `yarn install --mode=skip-build` *(fails: RequestError 403)*

------
https://chatgpt.com/codex/tasks/task_e_688c5f99362c832db8851a54ff3baea6