### PR TITLE
Change default attachment size

### DIFF
--- a/packages/plugins/@nocobase/plugin-file-manager/src/client/interfaces/attachment.ts
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/client/interfaces/attachment.ts
@@ -36,7 +36,8 @@ export class AttachmentFieldInterface extends CollectionFieldInterface {
     }
 
     if (['Table', 'Kanban'].includes(block)) {
-      schema['x-component-props']['size'] = 'small';
+      // Use a larger size for table and kanban blocks for better visibility
+      schema['x-component-props']['size'] = 'large';
     }
 
     schema['x-use-component-props'] = 'useAttachmentFieldProps';


### PR DESCRIPTION
## Summary
- increase default size for Table and Kanban blocks to `large` in `attachment.ts`

## Testing
- `yarn test` *(fails: This package doesn't seem to be present in your lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_688c63975aa0832d8a4d2e20ac35a936