### PR TITLE
Fix docker app to build from local source

### DIFF
--- a/docker/app-postgres/docker-compose.yml
+++ b/docker/app-postgres/docker-compose.yml
@@ -4,7 +4,9 @@ networks:
     driver: bridge
 services:
   app:
-    image: nocobase/nocobase:latest
+    build:
+      context: ../../
+      dockerfile: Dockerfile
     networks:
       - nocobase
     environment:


### PR DESCRIPTION
## Summary
- change `app` service in `docker/app-postgres/docker-compose.yml` to build from repo Dockerfile
- run lint and yarn install (failed due to 403)
- attempt docker build (docker not available)

## Testing
- `docker compose build app` *(fails: command not found)*
- `yarn install` *(fails: RequestError: Bad response: 403)*
- `yarn lint` *(fails: This package doesn't seem to be present in your lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_688c712351c8832d9c7b43fac29b7d38