### PR TITLE
Fix Verdaccio URL docs for Linux

### DIFF
--- a/.env.e2e.example
+++ b/.env.e2e.example
@@ -5,6 +5,8 @@ DB_MYSQL_PORT=10102
 DB_POSTGRES_PORT=10103
 VERDACCIO_PORT=10104
 # VERDACCIO_URL=http://host.docker.internal:10104/
+# Linux 环境下默认不会解析 host.docker.internal，可使用宿主机网关地址，例如：
+# VERDACCIO_URL=http://172.17.0.1:10104/
 
 ################# NOCOBASE APPLICATION #################
 

--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,8 @@ DB_MYSQL_PORT=10102
 DB_POSTGRES_PORT=10103
 VERDACCIO_PORT=10104
 # VERDACCIO_URL=http://host.docker.internal:10104/
+# Linux 环境下默认不会解析 host.docker.internal，可使用宿主机网关地址，例如：
+# VERDACCIO_URL=http://172.17.0.1:10104/
 
 ################# NOCOBASE APPLICATION #################
 


### PR DESCRIPTION
## Summary
- clarify that `host.docker.internal` doesn't resolve on Linux
- provide Linux example for `VERDACCIO_URL`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c81664198832d8bdaff3d8852b973