### PR TITLE
chore: skip release when registry unavailable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ RUN CURRENTVERSION="$(jq -r '.version' lerna.json)" && \
 RUN git config user.email "test@mail.com"  \
     && git config user.name "test" && git add .  \
     && git commit -m "chore(versions): test publish packages"
-RUN yarn release:force --registry $VERDACCIO_URL
+RUN yarn release:force --registry $VERDACCIO_URL || echo '⚠️ yarn release failed, skipping...'
 
 RUN yarn config set registry $VERDACCIO_URL
 WORKDIR /app

--- a/Dockerfile.pro
+++ b/Dockerfile.pro
@@ -22,7 +22,7 @@ RUN cd /tmp && \
 RUN git config user.email "test@mail.com"  \
   && git config user.name "test" && git add .  \
   && git commit -m "chore(versions): test publish packages"
-RUN yarn release:force --registry $VERDACCIO_URL
+RUN yarn release:force --registry $VERDACCIO_URL || echo '⚠️ yarn release failed, skipping...'
 
 RUN yarn config set registry $VERDACCIO_URL
 WORKDIR /app

--- a/docker/app-postgres/docker-compose.yml
+++ b/docker/app-postgres/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       context: ../../
       dockerfile: Dockerfile
       args:
-        VERDACCIO_URL: "http://verdaccio:4873"  # 构建阶段不访问它，安全保留
+        VERDACCIO_URL: "https://registry.npmjs.org"
     networks:
       - nocobase
     environment:
@@ -20,21 +20,17 @@ services:
       - DB_DATABASE=nocobase
       - DB_USER=nocobase
       - DB_PASSWORD=nocobase
-      - VERDACCIO_URL=http://registry.npmjs.org
+      - VERDACCIO_URL=https://registry.npmjs.org
     volumes:
       - ./storage:/app/nocobase/storage
     ports:
       - "13000:80"
     depends_on:
       - postgres
-      - verdaccio
     init: true
     command: >
       sh -c "
       echo '✔ App started';
-      echo '⏳ Waiting for verdaccio...';
-      sleep 5;
-      echo '🚀 Running yarn release:force';
       yarn release:force --registry $VERDACCIO_URL || echo '⚠️ yarn release 失败，跳过...';
       yarn start
       "
@@ -52,9 +48,3 @@ services:
     networks:
       - nocobase
 
-  verdaccio:
-    image: verdaccio/verdaccio
-    networks:
-      - nocobase
-    ports:
-      - "4873:4873"

--- a/docker/nocobase/Dockerfile-full
+++ b/docker/nocobase/Dockerfile-full
@@ -14,7 +14,7 @@ RUN cd /app \
   && cd /app/my-nocobase-app \
   && yarn config set registry "$VERDACCIO_URL" \
   && yarn install --production \
-  && yarn release:force --registry "$VERDACCIO_URL" \
+  && yarn release:force --registry "$VERDACCIO_URL" || echo '⚠️ yarn release failed, skipping...' \
   && rm -rf yarn.lock \
   && find node_modules -type f -name "yarn.lock" -delete \
   && find node_modules -type f -name "bower.json" -delete \


### PR DESCRIPTION
## Summary
- prevent Docker builds from failing when package release step can't reach a registry
- simplify Postgres example compose file to use public npm registry

## Testing
- `yarn lint` *(fails: ESLint couldn't find config)*
- `yarn test` *(fails: nocobase: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68905bd22a28832da533f7795be47934