### PR TITLE
fix docker app-postgres packaging

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -79,6 +79,14 @@ RUN rm -rf /etc/nginx/sites-enabled/default
 COPY ./docker/nocobase/nocobase.conf /etc/nginx/sites-enabled/nocobase.conf
 COPY --from=builder /app/nocobase.tar.gz /app/nocobase.tar.gz
 
+# Extract the application during build so that runtime commands
+# can rely on an existing package.json. This avoids runtime errors
+# when a custom command overrides the default entrypoint and tries
+# to run yarn before the app is unpacked.
+RUN mkdir -p /app/nocobase \
+  && tar -zxf /app/nocobase.tar.gz --absolute-names -C /app/nocobase \
+  && rm /app/nocobase.tar.gz
+
 WORKDIR /app/nocobase
 
 RUN mkdir -p /app/nocobase/storage/uploads/ && echo "$COMMIT_HASH" >> /app/nocobase/storage/uploads/COMMIT_HASH

--- a/docker/app-postgres/docker-compose.yml
+++ b/docker/app-postgres/docker-compose.yml
@@ -28,12 +28,6 @@ services:
     depends_on:
       - postgres
     init: true
-    command: >
-      sh -c "
-      echo '✔ App started';
-      yarn release:force --registry $VERDACCIO_URL || echo '⚠️ yarn release 失败，跳过...';
-      yarn start
-      "
 
   postgres:
     image: postgres:10


### PR DESCRIPTION
## Summary
- unpack nocobase archive during docker build so runtime has package.json
- rely on default entrypoint in app-postgres compose example

## Testing
- `bash -n docker/nocobase/docker-entrypoint.sh`
- `npm test` *(fails: nocobase: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689075532b1c832d8e4ee0d5cff254e6